### PR TITLE
feat: use the custom image for superset

### DIFF
--- a/terragrunt/main.tf
+++ b/terragrunt/main.tf
@@ -83,7 +83,7 @@ data "template_file" "superset-image" {
     AWS_LOGS_GROUP         = aws_cloudwatch_log_group.superset.name
     AWS_LOGS_REGION        = var.region
     AWS_LOGS_STREAM_PREFIX = "task"
-    SUPERSET_IMAGE         = "apache/superset:latest"
+    SUPERSET_IMAGE         = "${aws_ecr_repository.superset-image.repository_url}:latest"
     SUPERSET_SECRET_KEY    = "foo" # TODO: generate it and store it as a secret
   }
 }


### PR DESCRIPTION
The custom image is the same as the base superset image with one small difference it includes the superset_config.py file which will be needed to configure the solution. The config currently does nothing but write out a log.