### PR TITLE
feat: add RDS cluster for Superset data

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -12,6 +12,8 @@ env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 1.6.6
   TERRAGRUNT_VERSION: 0.54.5
+  TF_VAR_superset_database_username: ${{ secrets.SUPERSET_DATABASE_USERNAME }}
+  TF_VAR_superset_database_password: ${{ secrets.SUPERSET_DATABASE_PASSWORD }}
   TF_VAR_superset_secret_key: ${{ secrets.SUPERSET_SECRET_KEY }}
   
 permissions:

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -9,6 +9,8 @@ env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 1.6.6
   TERRAGRUNT_VERSION: 0.54.5
+  TF_VAR_superset_database_username: ${{ secrets.SUPERSET_DATABASE_USERNAME }}
+  TF_VAR_superset_database_password: ${{ secrets.SUPERSET_DATABASE_PASSWORD }}  
   TF_VAR_superset_secret_key: ${{ secrets.SUPERSET_SECRET_KEY }}
 
   

--- a/terragrunt/database.tf
+++ b/terragrunt/database.tf
@@ -1,0 +1,46 @@
+#
+# RDS Postgress cluster
+#
+module "superset_db" {
+  source = "github.com/cds-snc/terraform-modules//rds?ref=v9.0.4"
+  name   = "superset-${var.env}"
+
+  database_name  = "superset"
+  engine         = "aurora-postgresql"
+  engine_version = "15.5"
+  instances      = var.superset_database_instances_count
+  instance_class = var.superset_database_instance_class
+  username       = var.superset_database_username
+  password       = var.superset_database_password
+
+  backup_retention_period      = 14
+  preferred_backup_window      = "02:00-04:00"
+  performance_insights_enabled = true
+
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [aws_security_group.superset_db.id]
+
+  billing_tag_value = var.billing_code
+}
+
+resource "aws_ssm_parameter" "superset_database_host" {
+  name  = "superset_database_host"
+  type  = "SecureString"
+  value = module.superset_db.proxy_endpoint
+  tags  = local.common_tags
+}
+
+resource "aws_ssm_parameter" "superset_database_username" {
+  name  = "superset_database_username"
+  type  = "SecureString"
+  value = var.superset_database_username
+  tags  = local.common_tags
+}
+
+resource "aws_ssm_parameter" "superset_database_password" {
+  name  = "superset_database_password"
+  type  = "SecureString"
+  value = var.superset_database_password
+  tags  = local.common_tags
+}

--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -45,6 +45,9 @@ data "aws_iam_policy_document" "ssm_parameters" {
     ]
     resources = [
       aws_ssm_parameter.superset_secret_key.arn,
+      aws_ssm_parameter.superset_database_host.arn,
+      aws_ssm_parameter.superset_database_username.arn,
+      aws_ssm_parameter.superset_database_password.arn,
     ]
   }
 }

--- a/terragrunt/terragrunt.hcl
+++ b/terragrunt/terragrunt.hcl
@@ -15,13 +15,15 @@ inputs = {
   product_name = local.product_name
   region       = "ca-central-1"
   billing_code = local.cost_center_code
+
+  superset_database_instance_class  = "db.t3.medium"
+  superset_database_instances_count = 2
 }
 
 generate "provider" {
   path      = "provider.tf"
   if_exists = "overwrite"
   contents  = file("../common/provider.tf")
-
 }
 
 generate "common_variables" {

--- a/terragrunt/variables.tf
+++ b/terragrunt/variables.tf
@@ -1,3 +1,25 @@
+variable "superset_database_instances_count" {
+  description = "The number of instances in the database cluster."
+  type        = number
+}
+
+variable "superset_database_instance_class" {
+  description = "The instance class to use for the database."
+  type        = string
+}
+
+variable "superset_database_username" {
+  description = "The username to use for the database."
+  type        = string
+  sensitive   = true
+}
+
+variable "superset_database_password" {
+  description = "The password to use for the database."
+  type        = string
+  sensitive   = true
+}
+
 variable "superset_secret_key" {
   description = "Superset's secret key"
   type        = string


### PR DESCRIPTION
# Summary
Add a two instance Postgres Aurora RDS cluster to hold Superset's app data and configuration data.

# Related
- https://github.com/cds-snc/platform-core-services/issues/522