### PR TITLE
feat: setup Examples database and config

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -2,6 +2,11 @@ FROM apache/superset:3.0.2
 # Switching to root to install the required packages
 USER root
 
+# Required to create `examples` database as part of bootstrap
+# RUN apt-get update &&\
+#     apt-get install --no-install-recommends -y \
+#         postgresql-client
+
 # Example: installing a driver to connect to Redshift
 # Find which driver you need based on the analytics database
 # you want to connect to here:

--- a/containers/superset_config.py
+++ b/containers/superset_config.py
@@ -15,6 +15,13 @@ SQLALCHEMY_DATABASE_URI = (
     f"{DATABASE_HOST}/{DATABASE_DB}"
 )
 
+# Examples: remove for production use
+EXAMPLES_DB = os.getenv("EXAMPLES_DATABASE_DB")
+SQLALCHEMY_EXAMPLES_URI = (
+    f"postgresql://{DATABASE_USER}:{DATABASE_PASSWORD}@"
+    f"{DATABASE_HOST}/{EXAMPLES_DB}"
+)
+
 # Workers: https://superset.apache.org/docs/installation/async-queries-celery/
 CELERY_CONFIG = None
 

--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -1,6 +1,10 @@
 locals {
   container_environment = [
     {
+      "name"  = "EXAMPLES_DATABASE_DB"
+      "value" = "examples"
+    },    
+    {
       "name"  = "SUPERSET_DATABASE_DB"
       "value" = "superset"
     },
@@ -61,7 +65,7 @@ module "superset_ecs" {
 
 data "aws_iam_policy_document" "ecs_task_ssm_parameters" {
   statement {
-    sid    = "GetWeblateSSMParameters"
+    sid    = "GetSSMParameters"
     effect = "Allow"
     actions = [
       "ssm:GetParameter",
@@ -78,6 +82,7 @@ data "aws_iam_policy_document" "ecs_task_ssm_parameters" {
 
 data "aws_iam_policy_document" "ecs_task_create_tunnel" {
   statement {
+    sid    = "CreateSSMTunnel"
     effect = "Allow"
     actions = [
       "ssmmessages:CreateControlChannel",

--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -3,7 +3,7 @@ locals {
     {
       "name"  = "EXAMPLES_DATABASE_DB"
       "value" = "examples"
-    },    
+    },
     {
       "name"  = "SUPERSET_DATABASE_DB"
       "value" = "superset"


### PR DESCRIPTION
# Summary
Update the Superset config to include an Examples database URI.  This allows for the example data to be loaded with the following command:
```
superset load_examples --force
```

![image](https://github.com/cds-snc/cds-superset/assets/2110107/9314feb3-bd62-4df9-9009-8875880497f9)
# Related
- https://github.com/cds-snc/platform-core-services/issues/522