### PR TITLE
fix: add a port to redis URL in config

### DIFF
--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -10,7 +10,7 @@ locals {
     },
     {
       "name"  = "CACHE_REDIS_URL"
-      "value" = module.superset-redis.endpoint_address
+      "value" = "${module.superset-redis.endpoint_address}:${module.superset-redis.redis_port}"
     }
   ]
   container_secrets = [


### PR DESCRIPTION
Since we are having network issues and the docs have a part this adds a port to the configuration in the hopes it will work.

https://superset.apache.org/docs/installation/cache/