### PR TITLE
fix: Redis cache URL and env var key

### DIFF
--- a/containers/superset_config.py
+++ b/containers/superset_config.py
@@ -28,7 +28,7 @@ CELERY_CONFIG = None
 
 
 # Caching: https://superset.apache.org/docs/installation/cache
-REDIS_URL = os.getenv("REDIS_URL")
+REDIS_URL = os.getenv("CACHE_REDIS_URL")
 
 def redis_cache (key, timeout) :
     return {

--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -10,7 +10,7 @@ locals {
     },
     {
       "name"  = "CACHE_REDIS_URL"
-      "value" = "${module.superset-redis.endpoint_address}:${module.superset-redis.redis_port}"
+      "value" = "redis://${module.superset-redis.endpoint_address}:${module.superset-redis.redis_port}"
     }
   ]
   container_secrets = [


### PR DESCRIPTION
# Summary
Update the ECS task and Superset config to specify the Redis URL in the expected format.

# Related
- https://github.com/cds-snc/platform-core-services/issues/522