### PR TITLE
fix: Python Redis package version

### DIFF
--- a/containers/requirements.txt
+++ b/containers/requirements.txt
@@ -1,2 +1,2 @@
 authlib==1.3.0
-redis==5.0.1
+redis==4.6.0


### PR DESCRIPTION
# Summary
Superset has a constraint on the Redis package being `< 5.0`.

# Related
- https://github.com/cds-snc/platform-core-services/issues/522