### PR TITLE
feat: import glue crawler and athena table

### DIFF
--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -48,7 +48,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Terraform plan
-        uses: cds-snc/terraform-plan@v3.1.0
+        uses: cds-snc/terraform-plan@v3.2.0
         with:
           comment-delete: true
           comment-title: "Production"

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -9,7 +9,7 @@ env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 1.6.6
   TERRAGRUNT_VERSION: 0.54.5
-  TF_SUMMARIZE_VERSION: 0.3.7
+  TF_SUMMARIZE_VERSION: 0.3.5
   TF_VAR_google_oauth_client_id: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
   TF_VAR_google_oauth_client_secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
   TF_VAR_superset_database_username: ${{ secrets.SUPERSET_DATABASE_USERNAME }}

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -9,6 +9,7 @@ env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 1.6.6
   TERRAGRUNT_VERSION: 0.54.5
+  TF_SUMMARIZE_VERSION: 0.3.7
   TF_VAR_google_oauth_client_id: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
   TF_VAR_google_oauth_client_secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
   TF_VAR_superset_database_username: ${{ secrets.SUPERSET_DATABASE_USERNAME }}

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,6 @@ plan:
 		-var="superset_database_password=$(TF_VAR_SUPERSET_DATABASE_PASSWORD)" \
 		-var="superset_secret_key=$(TF_VAR_SUPERSET_SECRET_KEY)" \
 		--terragrunt-working-dir terragrunt
+	
+fmt:
+	@terraform fmt -recursive

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: plan
+plan: 
+	@terragrunt plan -var="google_oauth_client_id=$(TF_VAR_GOOGLE_OAUTH_CLIENT_ID)" \
+		-var="google_oauth_client_secret=$(TF_VAR_GOOGLE_OAUTH_CLIENT_SECRET)" \
+		-var="superset_database_username=$(TF_VAR_SUPERSET_DATABASE_USERNAME)" \
+		-var="superset_database_password=$(TF_VAR_SUPERSET_DATABASE_PASSWORD)" \
+		-var="superset_secret_key=$(TF_VAR_SUPERSET_SECRET_KEY)" \
+		--terragrunt-working-dir terragrunt

--- a/modules/aws/redis/input.tf
+++ b/modules/aws/redis/input.tf
@@ -15,7 +15,7 @@ variable "vpc_id" {}
 
 variable "allowed_security_groups" {
   default = {}
-  type = map(string)
+  type    = map(string)
 }
 
 variable "private_subnet_ids" {

--- a/terragrunt/glue.tf
+++ b/terragrunt/glue.tf
@@ -3,31 +3,31 @@ data "aws_s3_bucket" "cur_data_extract" {
 }
 
 resource "aws_glue_crawler" "cur_data_extract" {
- name = "Cost and Usage Report 2.0"
- database_name = "curdatabase"
- table_prefix = "cds_cur_export_crawler"
- role =  aws_iam_role.glue_crawler.arn
+  name          = "Cost and Usage Report 2.0"
+  database_name = "curdatabase"
+  table_prefix  = "cds_cur_export_crawler"
+  role          = aws_iam_role.glue_crawler.arn
   s3_target {
-    path="s3://${data.aws_s3_bucket.cur_data_extract.id}/cds_/DailyCostExports/"
- }
+    path = "s3://${data.aws_s3_bucket.cur_data_extract.id}/cds_/DailyCostExports/"
+  }
 
- configuration = jsonencode(
-  {
-    CrawlerOutput = {
-      Tables = {
-        TableThreshold = 2
+  configuration = jsonencode(
+    {
+      CrawlerOutput = {
+        Tables = {
+          TableThreshold = 2
+        }
       }
-    }
-    CreatePartitionIndex = true
-    Version         = 1
- })
+      CreatePartitionIndex = true
+      Version              = 1
+  })
 
   //Schedule once a day when we want it updating.
   //schedule = "cron(0 8 * * * *)"
 
- tags = {
+  tags = {
     Terraform = "true"
- }
+  }
 }
 
 import {
@@ -35,10 +35,10 @@ import {
   id = "Cost and Usage Report 2.0"
 }
 
-resource "aws_iam_role" "glue_crawler" { 
-  name = "AWSGlueServiceRole-cds_cur_extract_crawler"
+resource "aws_iam_role" "glue_crawler" {
+  name               = "AWSGlueServiceRole-cds_cur_extract_crawler"
   assume_role_policy = data.aws_iam_policy_document.glue.json
-  path = "/service-role/"
+  path               = "/service-role/"
   tags = {
     Terraform = "true"
   }
@@ -80,11 +80,11 @@ import {
 
 }
 
-resource "aws_iam_policy" "glue_s3_crawler"{
-  name = "AWSGlueServiceRole-cds_cur_extract_crawler-EZCRC-s3Policy"
-  policy = data.aws_iam_policy_document.glue_s3_crawler.json
+resource "aws_iam_policy" "glue_s3_crawler" {
+  name        = "AWSGlueServiceRole-cds_cur_extract_crawler-EZCRC-s3Policy"
+  policy      = data.aws_iam_policy_document.glue_s3_crawler.json
   description = "This policy will be used for Glue Crawler and Job execution. Please do NOT delete!"
-  path = "/service-role/"
+  path        = "/service-role/"
 }
 
 import {
@@ -92,7 +92,7 @@ import {
   id = "arn:aws:iam::066023111852:policy/service-role/AWSGlueServiceRole-cds_cur_extract_crawler-EZCRC-s3Policy"
 }
 
-data "aws_iam_policy_document" "glue_s3_crawler"{
+data "aws_iam_policy_document" "glue_s3_crawler" {
   statement {
     actions = [
       "s3:GetObject",
@@ -113,7 +113,7 @@ import {
 }
 
 resource "aws_athena_database" "cur_data_extract_database" {
-  name = "curdatabase"
+  name   = "curdatabase"
   bucket = data.aws_s3_bucket.cur_data_extract.id
 }
 

--- a/terragrunt/glue.tf
+++ b/terragrunt/glue.tf
@@ -1,0 +1,127 @@
+data "aws_s3_bucket" "cur_data_extract" {
+  bucket = "713f18dd-9f30-4976-a152-e81d48cf053a"
+}
+
+resource "aws_glue_crawler" "cur_data_extract" {
+ name = "Cost and Usage Report 2.0"
+ database_name = "curdatabase"
+ table_prefix = "cds_cur_export_crawler"
+ role =  aws_iam_role.glue_crawler.arn
+  s3_target {
+    path="s3://${data.aws_s3_bucket.cur_data_extract.id}/cds_/DailyCostExports/"
+ }
+
+ configuration = jsonencode(
+  {
+    CrawlerOutput = {
+      Tables = {
+        TableThreshold = 2
+      }
+    }
+    CreatePartitionIndex = true
+    Version         = 1
+ })
+
+  //Schedule once a day when we want it updating.
+  //schedule = "cron(0 8 * * * *)"
+
+ tags = {
+    Terraform = "true"
+ }
+}
+
+import {
+  to = aws_glue_crawler.cur_data_extract
+  id = "Cost and Usage Report 2.0"
+}
+
+resource "aws_iam_role" "glue_crawler" { 
+  name = "AWSGlueServiceRole-cds_cur_extract_crawler"
+  assume_role_policy = data.aws_iam_policy_document.glue.json
+  path = "/service-role/"
+  tags = {
+    Terraform = "true"
+  }
+}
+
+import {
+  to = aws_iam_role.glue_crawler
+  id = "AWSGlueServiceRole-cds_cur_extract_crawler"
+}
+
+data "aws_iam_policy_document" "glue" {
+  statement {
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type = "Service"
+
+      identifiers = [
+        "glue.amazonaws.com",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy" "AWSGlueServiceRole" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+}
+
+resource "aws_iam_role_policy_attachment" "glue_attach_policy" {
+  policy_arn = data.aws_iam_policy.AWSGlueServiceRole.arn
+  role       = aws_iam_role.glue_crawler.name
+}
+
+import {
+  to = aws_iam_role_policy_attachment.glue_attach_policy
+  id = "AWSGlueServiceRole-cds_cur_extract_crawler/arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
+
+}
+
+resource "aws_iam_policy" "glue_s3_crawler"{
+  name = "AWSGlueServiceRole-cds_cur_extract_crawler-EZCRC-s3Policy"
+  policy = data.aws_iam_policy_document.glue_s3_crawler.json
+  description = "This policy will be used for Glue Crawler and Job execution. Please do NOT delete!"
+  path = "/service-role/"
+}
+
+import {
+  to = aws_iam_policy.glue_s3_crawler
+  id = "arn:aws:iam::066023111852:policy/service-role/AWSGlueServiceRole-cds_cur_extract_crawler-EZCRC-s3Policy"
+}
+
+data "aws_iam_policy_document" "glue_s3_crawler"{
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject"
+    ]
+    resources = ["${data.aws_s3_bucket.cur_data_extract.arn}/cds_/DailyCostExports/*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "glue_s3_crawler" {
+  policy_arn = aws_iam_policy.glue_s3_crawler.arn
+  role       = aws_iam_role.glue_crawler.name
+}
+
+import {
+  to = aws_iam_role_policy_attachment.glue_s3_crawler
+  id = "AWSGlueServiceRole-cds_cur_extract_crawler/arn:aws:iam::066023111852:policy/service-role/AWSGlueServiceRole-cds_cur_extract_crawler-EZCRC-s3Policy"
+}
+
+resource "aws_athena_database" "cur_data_extract_database" {
+  name = "curdatabase"
+  bucket = data.aws_s3_bucket.cur_data_extract.id
+}
+
+import {
+  to = aws_athena_database.cur_data_extract_database
+  id = "curdatabase"
+}
+
+data "aws_s3_bucket" "cur_data_extract_queries" {
+  bucket = "calvinrodotestbucket"
+}


### PR DESCRIPTION
Imports a click-opsed glue crawler and athena table into terraform.
This should have all resources created,
One known exclusion because I'm tired and I didn't want to import it was the query bucket for athena database.

- On draft until we add import to terraform-plan
