### PR TITLE
feat: add `pyathena[pandas]` to support Athena datasources

### DIFF
--- a/containers/requirements.txt
+++ b/containers/requirements.txt
@@ -1,2 +1,3 @@
 authlib==1.3.0
+pyathena[pandas]==2.25.2
 redis==4.6.0

--- a/containers/superset_config.py
+++ b/containers/superset_config.py
@@ -24,7 +24,6 @@ SQLALCHEMY_EXAMPLES_URI = (
     f"{DATABASE_HOST}/{EXAMPLES_DB}"
 )
 
-
 # Workers: https://superset.apache.org/docs/installation/async-queries-celery/
 CELERY_CONFIG = None
 


### PR DESCRIPTION
# Summary
Add `pyathena[pandas]` to allow for Athena datasources.  The version selected is the highest compatible as listed in [Superset's setup.py](https://github.com/apache/superset/blob/71a950fc803898393fbe1c0b370aaca438eeb38b/setup.py#L139). 

# Related
- https://github.com/cds-snc/cds-superset/issues/21