### PR TITLE
feat: superset IAM role to read from Athena

### DIFF
--- a/terragrunt/athena_iam.tf
+++ b/terragrunt/athena_iam.tf
@@ -1,0 +1,95 @@
+resource "aws_iam_role" "superset_athena_read" {
+  name               = "SupersetAthenaRead"
+  description        = "This role allows the Superset ECS task to read from Athena as a datasource"
+  assume_role_policy = data.aws_iam_policy_document.superset_ecs_task_role.json
+
+  tags = {
+    Terraform = "true"
+  }
+
+  depends_on = [
+    module.superset_ecs
+  ]
+}
+
+data "aws_iam_policy_document" "superset_ecs_task_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${var.account_id}:role/superset_ecs_task_role",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_policy" "superset_athena_read" {
+  name   = "SupersetAthenaRead"
+  policy = data.aws_iam_policy_document.superset_athena_read.json
+
+  tags = {
+    Terraform = "true"
+  }
+}
+
+data "aws_iam_policy_document" "superset_athena_read" {
+  statement {
+    sid = "AthenaRead"
+    actions = [
+      "athena:BatchGetNamedQuery",
+      "athena:BatchGetQueryExecution",
+      "athena:GetNamedQuery",
+      "athena:GetQueryExecution",
+      "athena:GetQueryResults",
+      "athena:GetQueryResultsStream",
+      "athena:GetWorkGroup",
+      "athena:ListDatabases",
+      "athena:ListDataCatalogs",
+      "athena:ListNamedQueries",
+      "athena:ListQueryExecutions",
+      "athena:ListTagsForResource",
+      "athena:ListWorkGroups",
+      "athena:ListTableMetadata",
+      "athena:StartQueryExecution",
+      "athena:StopQueryExecution",
+      "athena:CreatePreparedStatement",
+      "athena:DeletePreparedStatement",
+      "athena:GetPreparedStatement"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "S3AthenaSourceBucketRead"
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:GetBucketLocation"
+    ]
+    resources = [
+      data.aws_s3_bucket.cur_data_extract.arn,
+      "${data.aws_s3_bucket.cur_data_extract.arn}/*"
+    ]
+  }
+
+  statement {
+    sid = "S3AthenaResultBucketWrite"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:AbortMultipartUpload",
+      "s3:ListBucket",
+      "s3:GetBucketLocation"
+    ]
+    resources = [
+      data.aws_s3_bucket.cur_data_extract_queries.arn,
+      "${data.aws_s3_bucket.cur_data_extract_queries.arn}/*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "superset_athena_read" {
+  policy_arn = aws_iam_policy.superset_athena_read.arn
+  role       = aws_iam_role.superset_athena_read.name
+}

--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -106,6 +106,19 @@ data "aws_iam_policy_document" "ecs_task_ssm_parameters" {
   }
 }
 
+data "aws_iam_policy_document" "ecs_task_assume_roles" {
+  statement {
+    sid    = "AssumeRoles"
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole"
+    ]
+    resources = [
+      "arn:aws:iam::${var.account_id}:role/SupersetAthenaRead"
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "ecs_task_create_tunnel" {
   statement {
     sid    = "CreateSSMTunnel"

--- a/terragrunt/glue.tf
+++ b/terragrunt/glue.tf
@@ -30,11 +30,6 @@ resource "aws_glue_crawler" "cur_data_extract" {
   }
 }
 
-import {
-  to = aws_glue_crawler.cur_data_extract
-  id = "Cost and Usage Report 2.0"
-}
-
 resource "aws_iam_role" "glue_crawler" {
   name               = "AWSGlueServiceRole-cds_cur_extract_crawler"
   assume_role_policy = data.aws_iam_policy_document.glue.json
@@ -42,11 +37,6 @@ resource "aws_iam_role" "glue_crawler" {
   tags = {
     Terraform = "true"
   }
-}
-
-import {
-  to = aws_iam_role.glue_crawler
-  id = "AWSGlueServiceRole-cds_cur_extract_crawler"
 }
 
 data "aws_iam_policy_document" "glue" {
@@ -74,22 +64,11 @@ resource "aws_iam_role_policy_attachment" "glue_attach_policy" {
   role       = aws_iam_role.glue_crawler.name
 }
 
-import {
-  to = aws_iam_role_policy_attachment.glue_attach_policy
-  id = "AWSGlueServiceRole-cds_cur_extract_crawler/arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
-
-}
-
 resource "aws_iam_policy" "glue_s3_crawler" {
   name        = "AWSGlueServiceRole-cds_cur_extract_crawler-EZCRC-s3Policy"
   policy      = data.aws_iam_policy_document.glue_s3_crawler.json
   description = "This policy will be used for Glue Crawler and Job execution. Please do NOT delete!"
   path        = "/service-role/"
-}
-
-import {
-  to = aws_iam_policy.glue_s3_crawler
-  id = "arn:aws:iam::066023111852:policy/service-role/AWSGlueServiceRole-cds_cur_extract_crawler-EZCRC-s3Policy"
 }
 
 data "aws_iam_policy_document" "glue_s3_crawler" {
@@ -107,19 +86,9 @@ resource "aws_iam_role_policy_attachment" "glue_s3_crawler" {
   role       = aws_iam_role.glue_crawler.name
 }
 
-import {
-  to = aws_iam_role_policy_attachment.glue_s3_crawler
-  id = "AWSGlueServiceRole-cds_cur_extract_crawler/arn:aws:iam::066023111852:policy/service-role/AWSGlueServiceRole-cds_cur_extract_crawler-EZCRC-s3Policy"
-}
-
 resource "aws_athena_database" "cur_data_extract_database" {
   name   = "curdatabase"
   bucket = data.aws_s3_bucket.cur_data_extract.id
-}
-
-import {
-  to = aws_athena_database.cur_data_extract_database
-  id = "curdatabase"
 }
 
 data "aws_s3_bucket" "cur_data_extract_queries" {


### PR DESCRIPTION
# Summary
Add the IAM role that will be assumed by the ECS
Superset task to read from Athena and its associated S3 buckets.

Remove the `import` statements as they have now been applied.

# Related
- https://github.com/cds-snc/cds-superset/issues/21