### PR TITLE
chore: switch to ECS module's task role ARN output

### DIFF
--- a/terragrunt/athena_iam.tf
+++ b/terragrunt/athena_iam.tf
@@ -6,10 +6,6 @@ resource "aws_iam_role" "superset_athena_read" {
   tags = {
     Terraform = "true"
   }
-
-  depends_on = [
-    module.superset_ecs
-  ]
 }
 
 data "aws_iam_policy_document" "superset_ecs_task_role" {
@@ -18,7 +14,7 @@ data "aws_iam_policy_document" "superset_ecs_task_role" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${var.account_id}:role/superset_ecs_task_role",
+        module.superset_ecs.task_role_arn
       ]
     }
   }

--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -54,7 +54,7 @@ locals {
 }
 
 module "superset_ecs" {
-  source = "github.com/cds-snc/terraform-modules//ecs?ref=v9.0.4"
+  source = "github.com/cds-snc/terraform-modules//ecs?ref=v9.0.5"
 
   cluster_name  = "superset"
   service_name  = "superset"


### PR DESCRIPTION
# Summary
Update the Athena IAM role's assume policy to use the ECS module's output to create an implicit dependency and avoid hardcoding.

# Related
- https://github.com/cds-snc/cds-superset/issues/21