### PR TITLE
feat: add workflow to deploy updated Superset image

### DIFF
--- a/.github/workflows/containers-apply.yml
+++ b/.github/workflows/containers-apply.yml
@@ -49,12 +49,12 @@ jobs:
       run: |
         docker build \
         --file ./containers/Dockerfile \
-        --tag $REGISTRY:$GITHUB_SHA \
+        --tag $REGISTRY:sha-$GITHUB_SHA \
         --tag $REGISTRY:latest ./containers
 
     - name: Push Container to Amazon ECR
       run: |
-        docker push $REGISTRY:$GITHUB_SHA
+        docker push $REGISTRY:sha-$GITHUB_SHA
         docker push $REGISTRY:latest
 
     - name: Docker generate SBOM

--- a/.github/workflows/containers-apply.yml
+++ b/.github/workflows/containers-apply.yml
@@ -1,5 +1,5 @@
 
-name: Container build and Push
+name: Container build and push
 on:
   push:
     branches:
@@ -32,7 +32,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    # TODO: Replace with a locked down IAM roel
+    # TODO: Replace with a locked down IAM role
     - name: configure aws credentials using OIDC
       uses: aws-actions/configure-aws-credentials@v4.0.1
       with:
@@ -49,14 +49,14 @@ jobs:
       run: |
         docker build \
         --file ./containers/Dockerfile \
-        --tag $REGISTRY:$GITHUB_SHA-`date '+%Y-%m-%d'` \
+        --tag $REGISTRY:$GITHUB_SHA \
         --tag $REGISTRY:latest ./containers
 
     - name: Push Container to Amazon ECR
       run: |
-        docker push $REGISTRY:$GITHUB_SHA-`date '+%Y-%m-%d'`
+        docker push $REGISTRY:$GITHUB_SHA
         docker push $REGISTRY:latest
-     
+
     - name: Docker generate SBOM
       uses: cds-snc/security-tools/.github/actions/generate-sbom@eecd7a02a0294b379411c126b61e5c29e253676a # v2.1.4
       with:

--- a/.github/workflows/containers-apply.yml
+++ b/.github/workflows/containers-apply.yml
@@ -10,7 +10,7 @@ on:
 
 env: 
   AWS_REGION: ca-central-1
-  REGISTRY: 066023111852.dkr.ecr.ca-central-1.amazonaws.com/superset
+  REGISTRY: ${{ vars.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/superset
   GITHUB_SHA: ${{ github.sha }}
 
 permissions:
@@ -36,7 +36,7 @@ jobs:
     - name: configure aws credentials using OIDC
       uses: aws-actions/configure-aws-credentials@v4.0.1
       with:
-        role-to-assume: arn:aws:iam::066023111852:role/cds-superset-apply 
+        role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-apply 
         role-session-name: PushContainer
         aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/containers-deploy.yml
+++ b/.github/workflows/containers-deploy.yml
@@ -49,7 +49,7 @@ jobs:
       with:
         task-definition: task-definition.json
         container-name: ${{ env.ECS_TASK }}
-        image: ${{ env.REGISTRY }}:${{ env.GITHUB_SHA }}
+        image: ${{ env.REGISTRY }}:sha-${{ env.GITHUB_SHA }}
 
     - name: Deploy updated ECS task
       uses: aws-actions/amazon-ecs-deploy-task-definition@v1

--- a/.github/workflows/containers-deploy.yml
+++ b/.github/workflows/containers-deploy.yml
@@ -1,0 +1,60 @@
+name: Containers deploy
+
+on:
+  workflow_run:
+    workflows: ["Container build and push"]
+    types:
+    - completed
+
+env: 
+  AWS_REGION: ca-central-1
+  ECS_CLUSTER: superset
+  ECS_SERVICE: superset
+  ECS_TASK: superset 
+  REGISTRY: 066023111852.dkr.ecr.ca-central-1.amazonaws.com/superset
+  GITHUB_SHA: ${{ github.sha }}
+
+permissions:
+  id-token: write
+
+jobs:
+  containers-deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Audit DNS requests
+      uses: cds-snc/dns-proxy-action@main
+      env:
+        DNS_PROXY_FORWARDTOSENTINEL: "true"
+        DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+        DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
+
+    # TODO: Replace with a locked down IAM role
+    - name: configure aws credentials using OIDC
+      uses: aws-actions/configure-aws-credentials@v4.0.1
+      with:
+        role-to-assume: arn:aws:iam::066023111852:role/cds-superset-apply 
+        role-session-name: DeployContainer
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Download ECS task definition
+      run: |
+        aws ecs describe-task-definition \
+          --task-definition ${{ env.ECS_TASK }} \
+          --query taskDefinition > task-definition.json
+
+    - name: Update ECS task image
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@v1
+      with:
+        task-definition: task-definition.json
+        container-name: ${{ env.ECS_TASK }}
+        image: ${{ env.REGISTRY }}:${{ env.GITHUB_SHA }}
+
+    - name: Deploy updated ECS task
+      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        service: ${{ env.ECS_SERVICE }}
+        cluster: ${{ env.ECS_CLUSTER }}
+        wait-for-service-stability: true

--- a/.github/workflows/containers-deploy.yml
+++ b/.github/workflows/containers-deploy.yml
@@ -11,7 +11,7 @@ env:
   ECS_CLUSTER: superset
   ECS_SERVICE: superset
   ECS_TASK: superset 
-  REGISTRY: 066023111852.dkr.ecr.ca-central-1.amazonaws.com/superset
+  REGISTRY: ${{ vars.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/superset
   GITHUB_SHA: ${{ github.sha }}
 
 permissions:
@@ -33,7 +33,7 @@ jobs:
     - name: configure aws credentials using OIDC
       uses: aws-actions/configure-aws-credentials@v4.0.1
       with:
-        role-to-assume: arn:aws:iam::066023111852:role/cds-superset-apply 
+        role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-apply 
         role-session-name: DeployContainer
         aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -45,7 +45,7 @@ jobs:
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
-          role-to-assume: arn:aws:iam::066023111852:role/cds-superset-apply 
+          role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-apply 
           role-session-name: TFApply
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -43,7 +43,7 @@ jobs:
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@v4.0.1
         with:
-          role-to-assume: arn:aws:iam::066023111852:role/cds-superset-plan 
+          role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-plan 
           role-session-name: TFPlan
           aws-region: ${{ env.AWS_REGION }}
 

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -1,25 +1,15 @@
 FROM apache/superset:3.0.2
-# Switching to root to install the required packages
 USER root
 
-# Required to create `examples` database as part of bootstrap
-# RUN apt-get update &&\
-#     apt-get install --no-install-recommends -y \
-#         postgresql-client
-
-# Example: installing a driver to connect to Redshift
-# Find which driver you need based on the analytics database
-# you want to connect to here:
+# Add required database driver packages
 # https://superset.apache.org/installation.html#database-dependencies
-
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache -r /app/requirements.txt
 ENV REQUIREMENTS_LOCAL=/app/requirements.txt
 
-# Example: add custom configuration
+# Add custom configuration
 # https://superset.apache.org/docs/installation/configuring-superset/#configuring-superset
 COPY superset_config.py /app/superset_config.py
 ENV SUPERSET_CONFIG_PATH /app/superset_config.py
 
-# Switching back to using the `superset` user
 USER superset

--- a/containers/superset_config.py
+++ b/containers/superset_config.py
@@ -17,13 +17,6 @@ SQLALCHEMY_DATABASE_URI = (
     f"{DATABASE_HOST}/{DATABASE_DB}"
 )
 
-# Examples: remove for production use
-EXAMPLES_DB = os.getenv("EXAMPLES_DATABASE_DB")
-SQLALCHEMY_EXAMPLES_URI = (
-    f"postgresql://{DATABASE_USER}:{DATABASE_PASSWORD}@"
-    f"{DATABASE_HOST}/{EXAMPLES_DB}"
-)
-
 # Workers: https://superset.apache.org/docs/installation/async-queries-celery/
 CELERY_CONFIG = None
 

--- a/terragrunt/ecr.tf
+++ b/terragrunt/ecr.tf
@@ -7,8 +7,8 @@ resource "aws_ecr_repository" "superset-image" {
   tags = local.common_tags
 }
 
-resource "aws_ecr_lifecycle_policy" "weblate" {
-  repository = aws_ecr_repository.weblate.name
+resource "aws_ecr_lifecycle_policy" "superset-image" {
+  repository = aws_ecr_repository.superset-image.name
   policy     = <<-EOT
   {
     "rules": [

--- a/terragrunt/ecr.tf
+++ b/terragrunt/ecr.tf
@@ -6,3 +6,41 @@ resource "aws_ecr_repository" "superset-image" {
   }
   tags = local.common_tags
 }
+
+resource "aws_ecr_lifecycle_policy" "weblate" {
+  repository = aws_ecr_repository.weblate.name
+  policy     = <<-EOT
+  {
+    "rules": [
+        {
+            "rulePriority": 10,
+            "description": "Keep last 10 git SHA tagged images",
+            "selection": {
+                "tagStatus": "tagged",
+                "tagPrefixList": [
+                    "sha-"
+                ],
+                "countType": "imageCountMoreThan",
+                "countNumber": 10
+            },
+            "action": {
+                "type": "expire"
+            }
+        },
+        {
+            "rulePriority": 20,
+            "description": "Expire untagged images older than 7 days",
+            "selection": {
+                "tagStatus": "untagged",
+                "countType": "sinceImagePushed",
+                "countUnit": "days",
+                "countNumber": 7
+            },
+            "action": {
+                "type": "expire"
+            }
+        }
+    ]
+  }
+  EOT
+}

--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -13,10 +13,6 @@ locals {
       "value" = "true"
     },
     {
-      "name"  = "EXAMPLES_DATABASE_DB"
-      "value" = "examples"
-    },
-    {
       "name"  = "SUPERSET_DATABASE_DB"
       "value" = "superset"
     },


### PR DESCRIPTION
# Summary
Add a GitHub workflow that deploys the newly build Superset
Docker image after it is built and pushed.

Add an ECR policy that removes old Docker images.

# Related
- Closes https://github.com/cds-snc/platform-core-services/issues/534