### PR TITLE
feat: add Celery worker and beat services

### DIFF
--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -58,7 +58,7 @@ locals {
 }
 
 module "superset_ecs" {
-  source = "github.com/cds-snc/terraform-modules//ecs?ref=v9.0.7"
+  source = "github.com/cds-snc/terraform-modules//ecs?ref=v9.1.0"
 
   cluster_name  = "superset"
   service_name  = "superset"
@@ -92,7 +92,7 @@ module "superset_ecs" {
 }
 
 module "celery_worker_ecs" {
-  source = "github.com/cds-snc/terraform-modules//ecs?ref=v9.0.7"
+  source = "github.com/cds-snc/terraform-modules//ecs?ref=v9.1.0"
 
   create_cluster = false
   cluster_name   = module.superset_ecs.cluster_name
@@ -126,7 +126,7 @@ module "celery_worker_ecs" {
 }
 
 module "celery_beat_ecs" {
-  source = "github.com/cds-snc/terraform-modules//ecs?ref=v9.0.7"
+  source = "github.com/cds-snc/terraform-modules//ecs?ref=v9.1.0"
 
   create_cluster = false
   cluster_name   = module.superset_ecs.cluster_name


### PR DESCRIPTION
# Summary
Add Celery worker/beat services to the Superset cluster.  These will be used to handle longer running SQL queries and schedule cleanup jobs.

# Related
- https://github.com/cds-snc/platform-core-services/issues/536