### PR TITLE
feat: add ECS task to upgrade Superset

### DIFF
--- a/containers/docker-bootstrap.sh
+++ b/containers/docker-bootstrap.sh
@@ -32,6 +32,12 @@ case "${1}" in
     echo "Starting web app..."
     /usr/bin/run-server.sh
     ;;
+  upgrade)
+    echo "Upgrading database..."
+    superset db upgrade
+    superset init
+    echo "All done 🌈"
+    ;; 
   *)
     echo "Unknown Operation!!!"
     ;;

--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -164,8 +164,8 @@ resource "aws_ecs_task_definition" "superset_upgrade" {
   family             = "superset-upgrade"
   cpu                = 1024
   memory             = 2048
-  execution_role_arn = module.superset.task_exec_role_arn
-  task_role_arn      = module.superset.task_role_arn
+  execution_role_arn = module.superset_ecs.task_exec_role_arn
+  task_role_arn      = module.superset_ecs.task_role_arn
   container_definitions = jsonencode([{
     name      = "superset-upgrade"
     cpu       = 1024
@@ -187,7 +187,7 @@ resource "aws_ecs_task_definition" "superset_upgrade" {
       logDriver = "awslogs",
       options = {
         awslogs-region        = var.region,
-        awslogs-group         = module.superset.cloudwatch_log_group_name,
+        awslogs-group         = module.superset_ecs.cloudwatch_log_group_name,
         awslogs-stream-prefix = "upgrade"
       }
     }

--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -10,7 +10,7 @@ locals {
     },
     {
       "name"  = "REDIS_PORT"
-      "value" = module.superset-redis.redis_port
+      "value" = "${tostring(module.superset-redis.redis_port)}"
     }
   ]
   container_env_google_auth = [

--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -159,6 +159,52 @@ module "celery_beat_ecs" {
   billing_tag_value = var.billing_code
 }
 
+# Create an ECS task that runs database upgrades
+resource "aws_ecs_task_definition" "superset_upgrade" {
+  family             = "superset-upgrade"
+  cpu                = 1024
+  memory             = 2048
+  execution_role_arn = module.superset.task_exec_role_arn
+  task_role_arn      = module.superset.task_role_arn
+  container_definitions = jsonencode([{
+    name      = "superset-upgrade"
+    cpu       = 1024
+    memory    = 2048
+    essential = true
+    command   = ["/app/docker/docker-bootstrap.sh", "upgrade"]
+    image     = "${aws_ecr_repository.superset-image.repository_url}:latest"
+    linuxParameters = {
+      capabilities : {
+        drop : ["ALL"]
+      }
+    }
+    portMappings = [{
+      hostPort : 8088,
+      containerPort : 8088,
+      protocol : "tcp"
+    }]
+    logConfiguration = {
+      logDriver = "awslogs",
+      options = {
+        awslogs-region        = var.region,
+        awslogs-group         = module.superset.cloudwatch_log_group_name,
+        awslogs-stream-prefix = "upgrade"
+      }
+    }
+    environment = local.container_env_all
+    secrets     = local.container_secrets_all
+  }])
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+
+  tags = local.common_tags
+}
+
+
 #
 # IAM policies
 #


### PR DESCRIPTION
# Summary
Add standalone ECS task that can upgrade the Superset database and re-initialize roles.  This task will be invoked via a GitHub workflow when a new Superset Docker image is deployed.

# Related
- https://github.com/cds-snc/platform-core-services/issues/539