### PR TITLE
feat: add autoscaling for Superset and Celery workers

### DIFF
--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -64,7 +64,12 @@ module "superset_ecs" {
   service_name  = "superset"
   task_cpu      = 1024
   task_memory   = 8192
-  desired_count = 1
+
+  # Scaling
+  enable_autoscaling       = true
+  desired_count            = 1
+  autoscaling_min_capacity = 1
+  autoscaling_max_capacity = 2  
 
   # Task definition
   container_image                     = "${aws_ecr_repository.superset-image.repository_url}:latest"
@@ -99,7 +104,12 @@ module "celery_worker_ecs" {
   service_name   = "celery-worker"
   task_cpu       = 512
   task_memory    = 1024
-  desired_count  = 1
+
+  # Scaling
+  enable_autoscaling       = true
+  desired_count            = 2
+  autoscaling_min_capacity = 2
+  autoscaling_max_capacity = 4
 
   # Task definition
   container_image                     = "${aws_ecr_repository.superset-image.repository_url}:latest"
@@ -133,7 +143,9 @@ module "celery_beat_ecs" {
   service_name   = "celery-beat"
   task_cpu       = 512
   task_memory    = 1024
-  desired_count  = 1
+
+  # Scaling: this must always be 1 or scheduling errors will occur
+  desired_count = 1
 
   # Task definition
   container_image                     = "${aws_ecr_repository.superset-image.repository_url}:latest"

--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -60,16 +60,16 @@ locals {
 module "superset_ecs" {
   source = "github.com/cds-snc/terraform-modules//ecs?ref=v9.1.0"
 
-  cluster_name  = "superset"
-  service_name  = "superset"
-  task_cpu      = 1024
-  task_memory   = 8192
+  cluster_name = "superset"
+  service_name = "superset"
+  task_cpu     = 1024
+  task_memory  = 8192
 
   # Scaling
   enable_autoscaling       = true
   desired_count            = 1
   autoscaling_min_capacity = 1
-  autoscaling_max_capacity = 2  
+  autoscaling_max_capacity = 2
 
   # Task definition
   container_image                     = "${aws_ecr_repository.superset-image.repository_url}:latest"


### PR DESCRIPTION
# Summary
Update the services to include CPU and memory autoscaling policies.

Update Celery to run 2 workers by default to test that things behave as expected with multiple workers.