### PR TITLE
chore: lower Celery task count

### DIFF
--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -107,9 +107,9 @@ module "celery_worker_ecs" {
 
   # Scaling
   enable_autoscaling       = true
-  desired_count            = 2
-  autoscaling_min_capacity = 2
-  autoscaling_max_capacity = 4
+  desired_count            = 1
+  autoscaling_min_capacity = 1
+  autoscaling_max_capacity = 2
 
   # Task definition
   container_image                     = "${aws_ecr_repository.superset-image.repository_url}:latest"


### PR DESCRIPTION
# Summary
Lower the Celery worker task count to 1 to save on costs.

Confirmed with the last PR that Celery workers are discovering each other as expected:
```
[2024-02-07 22:21:45,620: INFO/MainProcess] mingle: sync complete
[2024-02-07 22:21:45,620: INFO/MainProcess] mingle: sync with 2 nodes
[2024-02-07 22:21:44,612: INFO/MainProcess] sync with celery@ip-10-0-0-0.ca-central-1.compute.internal
[2024-02-07 22:21:44,612: INFO/MainProcess] sync with celery@ip-10-0-0-0.ca-central-1.compute.internal
[2024-02-07 22:21:44,590: INFO/MainProcess] Connected to redis://some-cluster-address:6379/0
[2024-02-07 22:21:44,595: INFO/MainProcess] mingle: searching for neighbors
```

# Related
- #47 