### PR TITLE
fix: Notify data crawler ignore S3 path

### DIFF
--- a/terragrunt/glue.tf
+++ b/terragrunt/glue.tf
@@ -44,7 +44,7 @@ resource "aws_glue_crawler" "notify" {
   configuration = jsonencode(
     {
       Grouping = {
-        TableGroupingPolicy = "CombineCompatibleSchemas" 
+        TableGroupingPolicy = "CombineCompatibleSchemas"
       }
       CrawlerOutput = {
         Tables = {

--- a/terragrunt/glue.tf
+++ b/terragrunt/glue.tf
@@ -43,6 +43,9 @@ resource "aws_glue_crawler" "notify" {
 
   configuration = jsonencode(
     {
+      Grouping = {
+        TableGroupingPolicy = "CombineCompatibleSchemas" 
+      }
       CrawlerOutput = {
         Tables = {
           TableThreshold = 10


### PR DESCRIPTION
# Summary
Update the Notify data crawler to consider table schemas when determining if a new or existing table should be used.

⚠️  This was applied locally to test.

# Related
- https://github.com/cds-snc/platform-core-services/issues/546