### PR TITLE
fix: remove Notify crawler schema grouping

### DIFF
--- a/terragrunt/glue.tf
+++ b/terragrunt/glue.tf
@@ -43,9 +43,6 @@ resource "aws_glue_crawler" "notify" {
 
   configuration = jsonencode(
     {
-      Grouping = {
-        TableGroupingPolicy = "CombineCompatibleSchemas"
-      }
       CrawlerOutput = {
         Tables = {
           TableThreshold = 10


### PR DESCRIPTION
# Summary
Remove the schema grouping by S3 path as this was causing all exported tables to be added to the same Glue table since they shared a common root path.

# Related
- https://github.com/cds-snc/platform-core-services/issues/546