### PR TITLE
fix: increase gunicorn timeout to deal with 502 errors

### DIFF
--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -1,6 +1,10 @@
 locals {
   container_env_all = [
     {
+      "name"  = "GUNICORN_KEEPALIVE"
+      "value" = "120"
+    },
+    {
       "name"  = "SUPERSET_DATABASE_DB"
       "value" = "superset"
     },


### PR DESCRIPTION
# Summary
The default gunicorn keepalive is 2s which is leading to intermittent 502 errors.  Since gunicorn is running behind an ALB it makes sense to set this higher.

Here is the error appearing that this should fix:
![image](https://github.com/cds-snc/cds-superset/assets/2110107/fc2f7f14-35a6-4f3d-a38c-98f7c72bd2e1)


# Related
- https://github.com/apache/superset/pull/20348
- https://docs.gunicorn.org/en/stable/settings.html#keepalive