### PR TITLE
chore: upgrade to latest RDS module

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,9 +17,9 @@
 			"installTools": false
 		},	
 		"ghcr.io/devcontainers/features/terraform:1": {
-			"version": "1.6.6",
+			"version": "1.8.2",
 			"tflint": "latest",
-			"terragrunt": "0.54.5"
+			"terragrunt": "0.58.3"
 		}
 	},
 

--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -10,8 +10,8 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.6.6
-  TERRAGRUNT_VERSION: 0.54.5
+  TERRAFORM_VERSION: 1.8.2
+  TERRAGRUNT_VERSION: 0.58.3
   TF_VAR_google_oauth_client_id: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
   TF_VAR_google_oauth_client_secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}  
   TF_VAR_superset_database_username: ${{ secrets.SUPERSET_DATABASE_USERNAME }}

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -7,8 +7,8 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.6.6
-  TERRAGRUNT_VERSION: 0.54.5
+  TERRAFORM_VERSION: 1.8.2
+  TERRAGRUNT_VERSION: 0.58.3
   TF_SUMMARIZE_VERSION: 0.3.5
   TF_VAR_google_oauth_client_id: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
   TF_VAR_google_oauth_client_secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}

--- a/terragrunt/database.tf
+++ b/terragrunt/database.tf
@@ -2,7 +2,7 @@
 # RDS Postgress cluster
 #
 module "superset_db" {
-  source = "github.com/cds-snc/terraform-modules//rds?ref=v9.4.2"
+  source = "github.com/cds-snc/terraform-modules//rds?ref=v9.4.4"
   name   = "superset-${var.env}"
 
   database_name  = "superset"
@@ -43,4 +43,14 @@ resource "aws_ssm_parameter" "superset_database_password" {
   type  = "SecureString"
   value = var.superset_database_password
   tags  = local.common_tags
+}
+
+import {
+  to = module.rds.aws_security_group_rule.rds_proxy_egress
+  id = "${module.rds.proxy_security_group_id}_egress_tcp_5432_5432_self"
+}
+
+import {
+  to = module.rds.aws_security_group_rule.rds_proxy_ingress
+  id = "${module.rds.proxy_security_group_id}_ingress_tcp_5432_5432_self"
 }

--- a/terragrunt/database.tf
+++ b/terragrunt/database.tf
@@ -47,10 +47,10 @@ resource "aws_ssm_parameter" "superset_database_password" {
 
 import {
   to = module.superset_db.aws_security_group_rule.rds_proxy_egress
-  id = "${module.rds.proxy_security_group_id}_egress_tcp_5432_5432_self"
+  id = "${module.superset_db.proxy_security_group_id}_egress_tcp_5432_5432_self"
 }
 
 import {
   to = module.superset_db.aws_security_group_rule.rds_proxy_ingress
-  id = "${module.rds.proxy_security_group_id}_ingress_tcp_5432_5432_self"
+  id = "${module.superset_db.proxy_security_group_id}_ingress_tcp_5432_5432_self"
 }

--- a/terragrunt/database.tf
+++ b/terragrunt/database.tf
@@ -46,11 +46,11 @@ resource "aws_ssm_parameter" "superset_database_password" {
 }
 
 import {
-  to = module.rds.aws_security_group_rule.rds_proxy_egress
+  to = module.superset_db.aws_security_group_rule.rds_proxy_egress
   id = "${module.rds.proxy_security_group_id}_egress_tcp_5432_5432_self"
 }
 
 import {
-  to = module.rds.aws_security_group_rule.rds_proxy_ingress
+  to = module.superset_db.aws_security_group_rule.rds_proxy_ingress
   id = "${module.rds.proxy_security_group_id}_ingress_tcp_5432_5432_self"
 }


### PR DESCRIPTION
# Summary
Upgrade to the latest RDS module, which changes to standalone security group rules.

This PR makes sure they are imported properly as Terraform does not handle inline SG rule changes well.

Also includes an update to Terraform and Terragrunt versions.

# Related
- https://github.com/cds-snc/terraform-modules/pull/481