### PR TITLE
chore: upgrade ALB to recommend SSL policy

### DIFF
--- a/terragrunt/load_balancer.tf
+++ b/terragrunt/load_balancer.tf
@@ -53,7 +53,7 @@ resource "aws_lb_listener" "superset" {
   load_balancer_arn = aws_lb.superset.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
   certificate_arn   = aws_acm_certificate.superset.arn
 
   default_action {


### PR DESCRIPTION
# Summary
Update to the latest recommend ALB SSL policy which is FIPS 140-3 compliant.