### PR TITLE
fix: Flask-Session 0.5.0 incompatibility with Werkzeug 3.0.0

### DIFF
--- a/containers/requirements.txt
+++ b/containers/requirements.txt
@@ -1,3 +1,4 @@
 authlib==1.3.2
+Flask-Session==0.8.0
 pyathena[pandas]==2.25.2
 redis==4.6.0


### PR DESCRIPTION
# Summary
Update to latest Flask-Session to fix an issue with using server-side user sessions.  This is being caused by Superset 4.0.2 using Werkzeug 3.0.0, which is not compatible with Flask-Session 0.5.0.

The error being thrown on server startup is:
```
TypeError: cannot use a string pattern on a bytes-like object
```

# Related
- https://github.com/apache/superset/issues/29695