### PR TITLE
feat: add CloudWatch alarms

### DIFF
--- a/.github/workflows/tf-apply.yml
+++ b/.github/workflows/tf-apply.yml
@@ -12,6 +12,7 @@ env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 1.8.2
   TERRAGRUNT_VERSION: 0.58.3
+  TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
   TF_VAR_google_oauth_client_id: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
   TF_VAR_google_oauth_client_secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}  
   TF_VAR_superset_database_username: ${{ secrets.SUPERSET_DATABASE_USERNAME }}

--- a/.github/workflows/tf-plan.yml
+++ b/.github/workflows/tf-plan.yml
@@ -10,6 +10,7 @@ env:
   TERRAFORM_VERSION: 1.8.2
   TERRAGRUNT_VERSION: 0.58.3
   TF_SUMMARIZE_VERSION: 0.3.5
+  TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
   TF_VAR_google_oauth_client_id: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
   TF_VAR_google_oauth_client_secret: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
   TF_VAR_superset_database_username: ${{ secrets.SUPERSET_DATABASE_USERNAME }}

--- a/terragrunt/alarms.tf
+++ b/terragrunt/alarms.tf
@@ -42,6 +42,8 @@ resource "aws_cloudwatch_metric_alarm" "superset_ecs_high_cpu" {
     ClusterName = module.superset_ecs.cluster_name
     ServiceName = each.key
   }
+
+  tags = local.common_tags
 }
 
 resource "aws_cloudwatch_metric_alarm" "superset_ecs_high_memory" {
@@ -65,6 +67,8 @@ resource "aws_cloudwatch_metric_alarm" "superset_ecs_high_memory" {
     ClusterName = module.superset_ecs.cluster_name
     ServiceName = each.key
   }
+
+  tags = local.common_tags
 }
 
 #
@@ -89,6 +93,8 @@ resource "aws_cloudwatch_metric_alarm" "superset_load_balancer_unhealthy_hosts" 
     LoadBalancer = aws_lb.superset.arn_suffix
     TargetGroup  = aws_lb_target_group.superset.arn_suffix
   }
+
+  tags = local.common_tags
 }
 
 resource "aws_cloudwatch_metric_alarm" "superset_load_balancer_healthy_hosts" {
@@ -110,6 +116,8 @@ resource "aws_cloudwatch_metric_alarm" "superset_load_balancer_healthy_hosts" {
     LoadBalancer = aws_lb.superset.arn_suffix
     TargetGroup  = aws_lb_target_group.superset.arn_suffix
   }
+
+  tags = local.common_tags
 }
 
 resource "aws_cloudwatch_metric_alarm" "superset_load_balancer_response_time" {
@@ -138,6 +146,8 @@ resource "aws_cloudwatch_metric_alarm" "superset_load_balancer_response_time" {
       }
     }
   }
+
+  tags = local.common_tags
 }
 
 #
@@ -174,6 +184,8 @@ resource "aws_cloudwatch_metric_alarm" "superset_ecs_errors" {
 
   alarm_actions = [aws_sns_topic.cloudwatch_alert_warning.arn]
   ok_actions    = [aws_sns_topic.cloudwatch_alert_ok.arn]
+
+  tags = local.common_tags
 }
 
 #

--- a/terragrunt/alarms.tf
+++ b/terragrunt/alarms.tf
@@ -198,7 +198,7 @@ resource "aws_cloudwatch_query_definition" "superset_ecs_errors" {
 
   query_string = <<-QUERY
     fields @timestamp, @message, @logStream
-    | filter @message like /ERROR/
+    | filter @message like /${join("|", local.superset_error_filters)}/
     | sort @timestamp desc
     | limit 100
   QUERY

--- a/terragrunt/alarms.tf
+++ b/terragrunt/alarms.tf
@@ -6,7 +6,7 @@ locals {
   ])
 
   superset_error_filters = [
-    "ERROR",
+    "CRITICAL", "ERROR"
   ]
   superset_error_filters_skip = [
     "Error on OAuth authorize"

--- a/terragrunt/alarms.tf
+++ b/terragrunt/alarms.tf
@@ -1,0 +1,192 @@
+locals {
+  ecs_services = toset([
+    module.superset_ecs,
+    module.celery_worker_ecs
+  ])
+
+  superset_error_filters = [
+    "ERROR",
+  ]
+  superset_error_filters_skip = [
+    "Error on OAuth authorize"
+  ]
+  superset_error_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.superset_error_filters)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.superset_error_filters_skip)}*\"]"
+
+  threshold_ecs_high_cpu     = 50
+  threshold_ecs_high_memory  = 50
+  threshold_lb_response_time = 1
+}
+
+#
+# ECS resource use
+#
+resource "aws_cloudwatch_metric_alarm" "superset_ecs_high_cpu" {
+  for_each = { for service in local.ecs_services : service.service_name => service }
+
+  alarm_name          = "ecs-${each.key}-high-cpu"
+  alarm_description   = ":warning: ${each.key} high CPU use over 2 minutes."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "120"
+  statistic           = "Maximum"
+  threshold           = local.threshold_ecs_high_cpu
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_alert_warning.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_alert_ok.arn]
+
+  dimensions = {
+    ClusterName = module.superset_ecs.cluster_name
+    ServiceName = each.key
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "superset_ecs_high_memory" {
+  for_each = { for service in local.ecs_services : service.service_name => service }
+
+  alarm_name          = "ecs-${each.key}-high-memory"
+  alarm_description   = ":warning: ${each.key} high memory use over 2 minutes."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = "120"
+  statistic           = "Maximum"
+  threshold           = local.threshold_ecs_high_memory
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_alert_warning.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_alert_ok.arn]
+
+  dimensions = {
+    ClusterName = module.superset_ecs.cluster_name
+    ServiceName = each.key
+  }
+}
+
+#
+# Load balancer
+#
+resource "aws_cloudwatch_metric_alarm" "superset_load_balancer_unhealthy_hosts" {
+  alarm_name          = "load-balancer-unhealthy-hosts"
+  alarm_description   = ":warning: there are unhealthy Superset load balancer hosts in a 1 minute period."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = "1"
+  evaluation_periods  = "1"
+  metric_name         = "UnHealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = "60"
+  statistic           = "Maximum"
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_alert_warning.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_alert_ok.arn]
+
+  dimensions = {
+    LoadBalancer = aws_lb.superset.arn_suffix
+    TargetGroup  = aws_lb_target_group.superset.arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "superset_load_balancer_healthy_hosts" {
+  alarm_name          = "load-balancer-healthy-hosts"
+  alarm_description   = ":dumpster-fire: there are no healthy hosts for the Superset load balance in a 1 minute period."
+  comparison_operator = "LessThanThreshold"
+  threshold           = "1"
+  evaluation_periods  = "1"
+  metric_name         = "HealthyHostCount"
+  namespace           = "AWS/ApplicationELB"
+  period              = "60"
+  statistic           = "Maximum"
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_alert_warning.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_alert_ok.arn]
+
+  dimensions = {
+    LoadBalancer = aws_lb.superset.arn_suffix
+    TargetGroup  = aws_lb_target_group.superset.arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "superset_load_balancer_response_time" {
+  alarm_name          = "load-balancer-response-time"
+  alarm_description   = ":warning: response time for the Superset load balancer is greater than 1 second over 5 minutes."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "5"
+  datapoints_to_alarm = "2"
+  threshold           = local.threshold_lb_response_time
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_alert_warning.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_alert_ok.arn]
+
+  metric_query {
+    id          = "response_time"
+    return_data = "true"
+    metric {
+      metric_name = "TargetResponseTime"
+      namespace   = "AWS/ApplicationELB"
+      period      = "60"
+      stat        = "Average"
+      dimensions = {
+        LoadBalancer = aws_lb.superset.arn_suffix
+        TargetGroup  = aws_lb_target_group.superset.arn_suffix
+      }
+    }
+  }
+}
+
+#
+# Errors logged
+#
+resource "aws_cloudwatch_log_metric_filter" "superset_ecs_errors" {
+  for_each = { for service in local.ecs_services : service.service_name => service }
+
+  name           = "${each.key}-error"
+  pattern        = local.superset_error_metric_pattern
+  log_group_name = each.value.cloudwatch_log_group_name
+
+  metric_transformation {
+    name          = "${each.key}-error"
+    namespace     = "superset"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "superset_ecs_errors" {
+  for_each = { for service in local.ecs_services : service.service_name => service }
+
+  alarm_name          = "errors-${each.key}"
+  alarm_description   = ":warning: ${each.key} errors logged over 1 minute."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.superset_ecs_errors[each.key].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.superset_ecs_errors[each.key].metric_transformation[0].namespace
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "0"
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_alert_warning.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_alert_ok.arn]
+}
+
+#
+# Log Insight queries
+#
+resource "aws_cloudwatch_query_definition" "superset_ecs_errors" {
+  name = "Superset - errors"
+
+  log_group_names = [for service in local.ecs_services : service.cloudwatch_log_group_name]
+
+  query_string = <<-QUERY
+    fields @timestamp, @message, @logStream
+    | filter @message like /ERROR/
+    | sort @timestamp desc
+    | limit 100
+  QUERY
+}

--- a/terragrunt/alarms.tf
+++ b/terragrunt/alarms.tf
@@ -1,6 +1,7 @@
 locals {
   ecs_services = toset([
     module.superset_ecs,
+    module.celery_beat_ecs,
     module.celery_worker_ecs
   ])
 

--- a/terragrunt/kms.tf
+++ b/terragrunt/kms.tf
@@ -1,0 +1,75 @@
+#
+# Encrypt messages sent to the CloudWatch alarm SNS topics
+#
+resource "aws_kms_key" "cloudwatch_alerts" {
+  description         = "SNS topic for CloudWatch alarm alerts"
+  enable_key_rotation = true
+  policy              = data.aws_iam_policy_document.kms_cloudwatch.json
+}
+
+data "aws_iam_policy_document" "kms_cloudwatch" {
+  # checkov:skip=CKV_AWS_109: `resources = ["*"]` identifies the KMS key to which the key policy is attached
+  # checkov:skip=CKV_AWS_111: `resources = ["*"]` identifies the KMS key to which the key policy is attached
+  # checkov:skip=CKV_AWS_356: `resources = ["*"]` identifies the KMS key to which the key policy is attached
+  statement {
+    sid       = "Enable IAM User Permissions"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.account_id}:root"]
+    }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${var.region}.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid    = "Allow_CloudWatch_for_CMK"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudwatch.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid    = "CloudwatchEvents"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}

--- a/terragrunt/kms.tf
+++ b/terragrunt/kms.tf
@@ -5,6 +5,8 @@ resource "aws_kms_key" "cloudwatch_alerts" {
   description         = "SNS topic for CloudWatch alarm alerts"
   enable_key_rotation = true
   policy              = data.aws_iam_policy_document.kms_cloudwatch.json
+
+  tags = local.common_tags
 }
 
 data "aws_iam_policy_document" "kms_cloudwatch" {

--- a/terragrunt/sns.tf
+++ b/terragrunt/sns.tf
@@ -3,12 +3,12 @@
 #
 resource "aws_sns_topic" "cloudwatch_alert_warning" {
   name              = "cloudwatch-alert-warning"
-  kms_master_key_id = aws_kms_key.cloudwatch.arn
+  kms_master_key_id = aws_kms_key.cloudwatch_alerts.arn
 }
 
 resource "aws_sns_topic" "cloudwatch_alert_ok" {
   name              = "cloudwatch-alert-ok"
-  kms_master_key_id = aws_kms_key.cloudwatch.arn
+  kms_master_key_id = aws_kms_key.cloudwatch_alerts.arn
 }
 
 #

--- a/terragrunt/sns.tf
+++ b/terragrunt/sns.tf
@@ -4,11 +4,13 @@
 resource "aws_sns_topic" "cloudwatch_alert_warning" {
   name              = "cloudwatch-alert-warning"
   kms_master_key_id = aws_kms_key.cloudwatch_alerts.arn
+  tags              = local.common_tags
 }
 
 resource "aws_sns_topic" "cloudwatch_alert_ok" {
   name              = "cloudwatch-alert-ok"
   kms_master_key_id = aws_kms_key.cloudwatch_alerts.arn
+  tags              = local.common_tags
 }
 
 #

--- a/terragrunt/sns.tf
+++ b/terragrunt/sns.tf
@@ -1,0 +1,91 @@
+#
+# SNS topics
+#
+resource "aws_sns_topic" "cloudwatch_alert_warning" {
+  name              = "cloudwatch-alert-warning"
+  kms_master_key_id = aws_kms_key.cloudwatch.arn
+}
+
+resource "aws_sns_topic" "cloudwatch_alert_ok" {
+  name              = "cloudwatch-alert-ok"
+  kms_master_key_id = aws_kms_key.cloudwatch.arn
+}
+
+#
+# SNS topic subscriptions
+#
+resource "aws_sns_topic_subscription" "cloudwatch_alert_warning" {
+  topic_arn = aws_sns_topic.cloudwatch_alert_warning.arn
+  protocol  = "https"
+  endpoint  = var.cloudwatch_alert_slack_webhook
+}
+
+resource "aws_sns_topic_subscription" "cloudwatch_alert_ok" {
+  topic_arn = aws_sns_topic.cloudwatch_alert_ok.arn
+  protocol  = "https"
+  endpoint  = var.cloudwatch_alert_slack_webhook
+}
+
+#
+# Allow CloudWatch to use the SNS topics
+#
+resource "aws_sns_topic_policy" "cloudwatch_alert_warning" {
+  arn    = aws_sns_topic.cloudwatch_alert_warning.arn
+  policy = data.aws_iam_policy_document.cloudwatch_events_sns_topic.json
+}
+
+resource "aws_sns_topic_policy" "cloudwatch_alert_ok" {
+  arn    = aws_sns_topic.cloudwatch_alert_ok.arn
+  policy = data.aws_iam_policy_document.cloudwatch_events_sns_topic.json
+}
+
+data "aws_iam_policy_document" "cloudwatch_events_sns_topic" {
+  statement {
+    # checkov:skip=CKV_AWS_111: False-positive, `resources = ["*"]` refers to the SNS topic the policy applies to 
+    # checkov:skip=CKV_AWS_356: False-positive, `resources = ["*"]` refers to the SNS topic the policy applies to 
+    sid    = "SNS_Default_Policy"
+    effect = "Allow"
+    actions = [
+      "SNS:Subscribe",
+      "SNS:SetTopicAttributes",
+      "SNS:RemovePermission",
+      "SNS:Receive",
+      "SNS:Publish",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:GetTopicAttributes",
+      "SNS:DeleteTopic",
+      "SNS:AddPermission",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+
+      values = [
+        var.account_id,
+      ]
+    }
+
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+
+  statement {
+    sid    = "SNS_Publish_statement"
+    effect = "Allow"
+    actions = [
+      "sns:Publish"
+    ]
+
+    resources = ["*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+  }
+}

--- a/terragrunt/variables.tf
+++ b/terragrunt/variables.tf
@@ -1,3 +1,9 @@
+variable "cloudwatch_alert_slack_webhook" {
+  description = "Slack webhook URL used by the CloudWatch alarm SNS topics."
+  type        = string
+  sensitive   = true
+}
+
 variable "google_oauth_client_id" {
   description = "Google OAuth client ID to enable logging in with Google."
   type        = string


### PR DESCRIPTION
# Summary
Add CloudWatch alarms to monitor ECS resource use, load balancer health and errors logged.
This includes the SNS topic/subscriptions and KMS key required to publish the alarms to Slack.

# Related
- https://github.com/cds-snc/platform-core-services/issues/606