### PR TITLE
feat: enable LB and WAF ACL logging

### DIFF
--- a/common/common_variables.tf
+++ b/common/common_variables.tf
@@ -3,6 +3,16 @@ variable "account_id" {
   type        = string
 }
 
+variable "billing_code" {
+  description = "The billing code to tag our resources with"
+  type        = string
+}
+
+variable "cbs_satellite_bucket_name" {
+  description = "The name of the Cloud Based Sensor satellite bucket"
+  type        = string
+}
+
 variable "domain" {
   description = "The domain to use for the service."
   type        = string
@@ -20,10 +30,5 @@ variable "product_name" {
 
 variable "region" {
   description = "The current AWS region"
-  type        = string
-}
-
-variable "billing_code" {
-  description = "The billing code to tag our resources with"
   type        = string
 }

--- a/terragrunt/alarms.tf
+++ b/terragrunt/alarms.tf
@@ -99,7 +99,7 @@ resource "aws_cloudwatch_metric_alarm" "superset_load_balancer_unhealthy_hosts" 
 
 resource "aws_cloudwatch_metric_alarm" "superset_load_balancer_healthy_hosts" {
   alarm_name          = "load-balancer-healthy-hosts"
-  alarm_description   = ":dumpster-fire: there are no healthy hosts for the Superset load balance in a 1 minute period."
+  alarm_description   = ":dumpster-fire: there are no healthy hosts for the Superset load balancer in a 1 minute period."
   comparison_operator = "LessThanThreshold"
   threshold           = "1"
   evaluation_periods  = "1"

--- a/terragrunt/athena.tf
+++ b/terragrunt/athena.tf
@@ -1,0 +1,34 @@
+#
+# Create Athena queries to view the WAF and load balancer access logs
+#
+module "athena_access_logs" {
+  source = "github.com/cds-snc/terraform-modules//athena_access_logs?ref=v9.6.7"
+
+  athena_bucket_name = module.athena_bucket.s3_bucket_id
+
+  lb_access_queries_create   = true
+  lb_access_log_bucket_name  = var.cbs_satellite_bucket_name
+  waf_access_queries_create  = true
+  waf_access_log_bucket_name = var.cbs_satellite_bucket_name
+
+  billing_tag_value = var.billing_code
+}
+
+#
+# Hold the Athena data
+#
+module "athena_bucket" {
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v9.6.7"
+  bucket_name       = "${var.product_name}-${var.env}-athena"
+  billing_tag_value = var.billing_code
+
+  lifecycle_rule = [
+    {
+      id      = "expire-objects"
+      enabled = true
+      expiration = {
+        days = 30
+      }
+    },
+  ]
+}

--- a/terragrunt/load_balancer.tf
+++ b/terragrunt/load_balancer.tf
@@ -6,6 +6,12 @@ resource "aws_lb" "superset" {
   drop_invalid_header_fields = true
   enable_deletion_protection = true
 
+  access_logs {
+    bucket  = var.cbs_satellite_bucket_name
+    prefix  = "lb_logs"
+    enabled = true
+  }
+
   security_groups = [
     aws_security_group.superset_lb.id
   ]

--- a/terragrunt/terragrunt.hcl
+++ b/terragrunt/terragrunt.hcl
@@ -6,7 +6,7 @@ locals {
   cost_center_code = "${local.product_name}-${local.env}"
 }
 
-# DO NOT CHANGE ANYTHING BELOW HERE UNLESS YOU KNOW WHAT YOU ARE DOING
+# DO NOT CHANGE ANYTHING BELOW HERE UNLESS YOU KNOW WHAT YOU ARE DOING, or, you feel like learning things on the fly
 
 inputs = {
   account_id                = local.account_id

--- a/terragrunt/terragrunt.hcl
+++ b/terragrunt/terragrunt.hcl
@@ -9,12 +9,13 @@ locals {
 # DO NOT CHANGE ANYTHING BELOW HERE UNLESS YOU KNOW WHAT YOU ARE DOING
 
 inputs = {
-  account_id   = local.account_id
-  domain       = local.domain
-  env          = local.env
-  product_name = local.product_name
-  region       = "ca-central-1"
-  billing_code = local.cost_center_code
+  account_id                = local.account_id
+  domain                    = local.domain
+  env                       = local.env
+  product_name              = local.product_name
+  region                    = "ca-central-1"
+  billing_code              = local.cost_center_code
+  cbs_satellite_bucket_name = "cbs-satellite-${local.account_id}"
 
   superset_database_instance_class  = "db.t3.medium"
   superset_database_instances_count = 2

--- a/terragrunt/waf.tf
+++ b/terragrunt/waf.tf
@@ -289,8 +289,8 @@ resource "aws_iam_role" "superset_waf_logs" {
 
 resource "aws_iam_role_policy" "superset_waf_logs" {
   name   = "superset-waf-logs"
-  role   = aws_iam_role.firehose_waf_logs.id
-  policy = data.aws_iam_policy_document.firehose_waf_policy.json
+  role   = aws_iam_role.superset_waf_logs.id
+  policy = data.aws_iam_policy_document.superset_waf_logs.json
 }
 
 data "aws_iam_policy_document" "superset_waf_logs_assume" {

--- a/terragrunt/waf.tf
+++ b/terragrunt/waf.tf
@@ -284,7 +284,7 @@ resource "aws_kinesis_firehose_delivery_stream" "superset_waf_logs" {
 #
 resource "aws_iam_role" "superset_waf_logs" {
   name               = "superset-waf-logs"
-  assume_role_policy = data.aws_iam_policy_document.superset_waf_logs.json
+  assume_role_policy = data.aws_iam_policy_document.superset_waf_logs_assume.json
 }
 
 resource "aws_iam_role_policy" "superset_waf_logs" {
@@ -293,7 +293,7 @@ resource "aws_iam_role_policy" "superset_waf_logs" {
   policy = data.aws_iam_policy_document.firehose_waf_policy.json
 }
 
-data "aws_iam_policy_document" "superset_waf_logs" {
+data "aws_iam_policy_document" "superset_waf_logs_assume" {
   statement {
     actions = ["sts:AssumeRole"]
     principals {

--- a/terragrunt/waf.tf
+++ b/terragrunt/waf.tf
@@ -1,5 +1,6 @@
 locals {
-  excluded_common_rules = []
+  excluded_common_rules    = []
+  cbs_satellite_bucket_arn = "arn:aws:s3:::${var.cbs_satellite_bucket_name}"
 }
 
 #
@@ -251,4 +252,81 @@ resource "aws_wafv2_rule_group" "rate_limiters_group" {
 resource "aws_wafv2_web_acl_association" "superset" {
   resource_arn = aws_lb.superset.arn
   web_acl_arn  = aws_wafv2_web_acl.superset.arn
+}
+
+#
+# WAF logging
+#
+resource "aws_wafv2_web_acl_logging_configuration" "superset_waf_logs" {
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.superset_waf_logs.arn]
+  resource_arn            = aws_wafv2_web_acl.superset.arn
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "superset_waf_logs" {
+  # checkov:skip=CKV_AWS_241: Encryption using CMK not required
+  name        = "aws-waf-logs-superset"
+  destination = "extended_s3"
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  extended_s3_configuration {
+    role_arn           = aws_iam_role.superset_waf_logs.arn
+    prefix             = "waf_acl_logs/AWSLogs/${var.account_id}/"
+    bucket_arn         = local.cbs_satellite_bucket_arn
+    compression_format = "GZIP"
+  }
+}
+
+#
+# WAF logging IAM role
+#
+resource "aws_iam_role" "superset_waf_logs" {
+  name               = "superset-waf-logs"
+  assume_role_policy = data.aws_iam_policy_document.superset_waf_logs.json
+}
+
+resource "aws_iam_role_policy" "superset_waf_logs" {
+  name   = "superset-waf-logs"
+  role   = aws_iam_role.firehose_waf_logs.id
+  policy = data.aws_iam_policy_document.firehose_waf_policy.json
+}
+
+data "aws_iam_policy_document" "superset_waf_logs" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "superset_waf_logs" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:PutObject"
+    ]
+    resources = [
+      local.cbs_satellite_bucket_arn,
+      "${local.cbs_satellite_bucket_arn}/*"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:CreateServiceLinkedRole"
+    ]
+    resources = [
+      "arn:aws:iam::*:role/aws-service-role/wafv2.amazonaws.com/AWSServiceRoleForWAFV2Logging"
+    ]
+  }
 }


### PR DESCRIPTION
# Summary
Update the WAF ACL and load balancer to send their logs to the Cloud Based Sensor satellite bucket.

Create the Athena workgroup and database required to query these logs.

Fix a typo in one of the alarm descriptions.

# Related
- https://github.com/cds-snc/platform-core-services/issues/614