### PR TITLE
fix: adjust Superset ECS resources

### DIFF
--- a/terragrunt/alarms.tf
+++ b/terragrunt/alarms.tf
@@ -26,12 +26,12 @@ resource "aws_cloudwatch_metric_alarm" "superset_ecs_high_cpu" {
   for_each = { for service in local.ecs_services : service.service_name => service }
 
   alarm_name          = "ecs-${each.key}-high-cpu"
-  alarm_description   = "`${each.key}` high CPU use over 2 minutes."
+  alarm_description   = "`${each.key}` high CPU use over 5 minutes."
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = "5"
   metric_name         = "CPUUtilization"
   namespace           = "AWS/ECS"
-  period              = "120"
+  period              = "60"
   statistic           = "Maximum"
   threshold           = local.threshold_ecs_high_cpu
   treat_missing_data  = "notBreaching"
@@ -51,12 +51,12 @@ resource "aws_cloudwatch_metric_alarm" "superset_ecs_high_memory" {
   for_each = { for service in local.ecs_services : service.service_name => service }
 
   alarm_name          = "ecs-${each.key}-high-memory"
-  alarm_description   = "`${each.key}` high memory use over 2 minutes."
+  alarm_description   = "`${each.key}` high memory use over 5 minutes."
   comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = "5"
   metric_name         = "MemoryUtilization"
   namespace           = "AWS/ECS"
-  period              = "120"
+  period              = "60"
   statistic           = "Maximum"
   threshold           = local.threshold_ecs_high_memory
   treat_missing_data  = "notBreaching"

--- a/terragrunt/alarms.tf
+++ b/terragrunt/alarms.tf
@@ -14,8 +14,8 @@ locals {
   ]
   superset_error_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.superset_error_filters)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.superset_error_filters_skip)}*\"]"
 
-  threshold_ecs_high_cpu     = 50
-  threshold_ecs_high_memory  = 50
+  threshold_ecs_high_cpu     = 80
+  threshold_ecs_high_memory  = 80
   threshold_lb_response_time = 1
 }
 

--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -66,7 +66,7 @@ module "superset_ecs" {
 
   cluster_name = "superset"
   service_name = "superset"
-  task_cpu     = 1024
+  task_cpu     = 2048
   task_memory  = 8192
 
   # Scaling


### PR DESCRIPTION
# Summary
Increase the vCPU to 2 and raise the alarm threshold for resource use.  This will reduce the number of resource alarms we have been seeing for low use patterns.