### PR TITLE
fix: raise threshold for load balancer response time alarm

### DIFF
--- a/terragrunt/alarms.tf
+++ b/terragrunt/alarms.tf
@@ -16,7 +16,7 @@ locals {
 
   threshold_ecs_high_cpu     = 80
   threshold_ecs_high_memory  = 80
-  threshold_lb_response_time = 1
+  threshold_lb_response_time = 2
 }
 
 #
@@ -123,10 +123,10 @@ resource "aws_cloudwatch_metric_alarm" "superset_load_balancer_healthy_hosts" {
 
 resource "aws_cloudwatch_metric_alarm" "superset_load_balancer_response_time" {
   alarm_name          = "load-balancer-response-time"
-  alarm_description   = "Response time for the Superset load balancer is greater than 1 second over 5 minutes."
+  alarm_description   = "Response time for the Superset load balancer is greater than 2 seconds over 5 minutes."
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "5"
-  datapoints_to_alarm = "2"
+  datapoints_to_alarm = "3"
   threshold           = local.threshold_lb_response_time
   treat_missing_data  = "notBreaching"
 


### PR DESCRIPTION
# Summary
Increase the LB response time alarm threshold so that the alarm triggers after 3 datapoints within a 5 minute period with a response time > 2 seconds.

This is being done because the Superset dashboard load can be slow for non-cached query results.