### PR TITLE
fix: docker deploy workflow name trigger

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -2,7 +2,7 @@ name: Docker deploy
 
 on:
   workflow_run:
-    workflows: ["Container build and push"]
+    workflows: ["Docker build and push"]
     types:
     - completed
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ COPY superset_config.py /app/superset_config.py
 ENV SUPERSET_CONFIG_PATH=/app/superset_config.py
 
 # Code overrides
-# BUG in 4.1.1 for cache warming.  Remove when the fix is released.
+# BUG in v4.1.1 for cache warming.  Remove when the fix is released.
 COPY superset/tasks/utils.py /app/superset/tasks/utils.py
 
 USER superset


### PR DESCRIPTION
# Summary
Update the Docker deploy workflow so that its triggering workflow's name is correct.

Also make a minor Docker image change to trigger a redeploy and DB upgrade.