### PR TITLE
fix: ReadOnly role data access

### DIFF
--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -134,11 +134,15 @@ SIP_15_ENABLED = True
 # Custom roles
 FAB_ROLES = {
     "ReadOnly": [
-        [".*", "can_list"],
-        [".*", "can_show"],
-        [".*", "menu_access"],
-        [".*", "can_get"],
         [".*", "can_info"],
+        [".*", "can_list"],
+        [".*", "can_get"],
+        [".*", "can_external_metadata"],
+        [".*", "can_external_metadata_by_name"],
+        [".*", "can_read"],
+        [".*", "can_show"],
+        ["all_datasource_access", "all_datasource_access"],
+        ["all_database_access", "all_database_access"],
     ],
     "CacheWarmer": [
         [".*", "can_warm_up_cache"],


### PR DESCRIPTION
# Summary
Update the `ReadOnly` role so that it can access all data sources.  This may be scaled back as we add more data sources.

# Related
- https://github.com/cds-snc/platform-core-services/issues/626