### PR TITLE
fix: suppress all generic DB errors

### DIFF
--- a/terragrunt/alarms.tf
+++ b/terragrunt/alarms.tf
@@ -10,9 +10,9 @@ locals {
   ]
   superset_error_filters_skip = [
     "'Template' object has no attribute 'strip'",
-    "COLUMN_NOT_FOUND",
     "Error on OAuth authorize",
     "Failed to execute query",
+    "GENERIC_DB_ENGINE_ERROR",
     "SYNTAX_ERROR"
   ]
   superset_error_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.superset_error_filters)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.superset_error_filters_skip)}*\"]"

--- a/terragrunt/ecs.tf
+++ b/terragrunt/ecs.tf
@@ -114,8 +114,8 @@ module "celery_worker_ecs" {
   create_cluster = false
   cluster_name   = module.superset_ecs.cluster_name
   service_name   = "celery-worker"
-  task_cpu       = 512
-  task_memory    = 1024
+  task_cpu       = 1024
+  task_memory    = 2048
 
   # Scaling
   enable_autoscaling       = true


### PR DESCRIPTION
# Summary
Update the CloudWatch alarm filters to avoid triggering an alarm when the user has caused a generic DB error.  These are caused by query syntax issues.