### PR TITLE
feat: create new Production hosted zone

### DIFF
--- a/terragrunt/aws/route53.tf
+++ b/terragrunt/aws/route53.tf
@@ -14,3 +14,8 @@ resource "aws_route53_record" "superset_A" {
     evaluate_target_health = false
   }
 }
+
+resource "aws_route53_zone" "superset_prod" {
+  name = var.domain_prod
+  tags = local.common_tags
+}

--- a/terragrunt/env/common/common_variables.tf
+++ b/terragrunt/env/common/common_variables.tf
@@ -18,6 +18,11 @@ variable "domain" {
   type        = string
 }
 
+variable "domain_prod" {
+  description = "The production domain to use for the service."
+  type        = string
+}
+
 variable "env" {
   description = "The current running environment"
   type        = string

--- a/terragrunt/env/prod/env_vars.hcl
+++ b/terragrunt/env/prod/env_vars.hcl
@@ -1,6 +1,6 @@
 inputs = {
   account_id   = "066023111852"
-  domain       = "superset.cdssandbox.xyz"
+  domain       = "superset.alpha.canada.ca"
   env          = "prod"
   region       = "ca-central-1"
   product_name = "cds-superset"

--- a/terragrunt/env/prod/env_vars.hcl
+++ b/terragrunt/env/prod/env_vars.hcl
@@ -1,6 +1,7 @@
 inputs = {
   account_id   = "066023111852"
-  domain       = "superset.alpha.canada.ca"
+  domain       = "superset.cdssandbox.xyz"
+  domain_prod  = "superset.alpha.canada.ca"
   env          = "prod"
   region       = "ca-central-1"
   product_name = "cds-superset"

--- a/terragrunt/env/terragrunt.hcl
+++ b/terragrunt/env/terragrunt.hcl
@@ -6,6 +6,7 @@ locals {
 inputs = {
   account_id                = local.vars.inputs.account_id
   domain                    = local.vars.inputs.domain
+  domain_prod               = local.vars.inputs.domain_prod
   env                       = local.vars.inputs.env
   product_name              = local.vars.inputs.product_name
   region                    = local.vars.inputs.region


### PR DESCRIPTION
# Summary
Add a new Prod `superset.alpha.canada.ca` hosted zone as part of the Staging environment setup.  This will help reduce the downtime of the switch.

# Related
- https://github.com/cds-snc/platform-core-services/issues/617