### PR TITLE
feat: switch to new alpha.canada.ca domain

### DIFF
--- a/terragrunt/aws/route53.tf
+++ b/terragrunt/aws/route53.tf
@@ -15,7 +15,7 @@ resource "aws_route53_record" "superset_A" {
   }
 }
 
-resource "aws_route53_zone" "superset_prod" {
-  name = var.domain_prod
-  tags = local.common_tags
+moved {
+  from = aws_route53_zone.superset_prod
+  to   = aws_route53_zone.superset
 }

--- a/terragrunt/env/common/common_variables.tf
+++ b/terragrunt/env/common/common_variables.tf
@@ -18,11 +18,6 @@ variable "domain" {
   type        = string
 }
 
-variable "domain_prod" {
-  description = "The production domain to use for the service."
-  type        = string
-}
-
 variable "env" {
   description = "The current running environment"
   type        = string

--- a/terragrunt/env/prod/env_vars.hcl
+++ b/terragrunt/env/prod/env_vars.hcl
@@ -1,7 +1,6 @@
 inputs = {
   account_id   = "066023111852"
-  domain       = "superset.cdssandbox.xyz"
-  domain_prod  = "superset.alpha.canada.ca"
+  domain       = "superset.alpha.canada.ca"
   env          = "prod"
   region       = "ca-central-1"
   product_name = "cds-superset"

--- a/terragrunt/env/terragrunt.hcl
+++ b/terragrunt/env/terragrunt.hcl
@@ -6,7 +6,6 @@ locals {
 inputs = {
   account_id                = local.vars.inputs.account_id
   domain                    = local.vars.inputs.domain
-  domain_prod               = local.vars.inputs.domain_prod
   env                       = local.vars.inputs.env
   product_name              = local.vars.inputs.product_name
   region                    = local.vars.inputs.region


### PR DESCRIPTION
# Summary
Update prod to use the `superset.alpha.canada.ca` domain.

# Related
- https://github.com/cds-snc/platform-core-services/issues/617