### PR TITLE
fix: switch prod URL to superset.cds-snc.ca

### DIFF
--- a/terragrunt/aws/route53.tf
+++ b/terragrunt/aws/route53.tf
@@ -15,7 +15,9 @@ resource "aws_route53_record" "superset_A" {
   }
 }
 
-moved {
-  from = aws_route53_zone.superset_prod
-  to   = aws_route53_zone.superset
+resource "aws_route53_zone" "superset_cds_snc" {
+  count = var.env == "production" ? 1 : 0
+
+  name = "superset.cds-snc.ca"
+  tags = local.common_tags
 }

--- a/terragrunt/aws/route53.tf
+++ b/terragrunt/aws/route53.tf
@@ -16,7 +16,7 @@ resource "aws_route53_record" "superset_A" {
 }
 
 resource "aws_route53_zone" "superset_cds_snc" {
-  count = var.env == "production" ? 1 : 0
+  count = var.env == "prod" ? 1 : 0
 
   name = "superset.cds-snc.ca"
   tags = local.common_tags


### PR DESCRIPTION
# Summary
Updating the production url to be a subdomain of the cds-snc.ca domain as this is an internal tool. This will be a new pattern going forward for tools that are only for CDS use.

As with the previous domain migration this is step 1 of 2 to minimize downtime during the switch.

# Related
- https://github.com/cds-snc/platform-core-services/issues/617