### PR TITLE
feat: split Staging and Prod deploy workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Users that are allowed to approve a release PR
+.release-please-manifest.json @cds-snc/platform-core-services

--- a/.github/workflows/docker-apply-prod.yml
+++ b/.github/workflows/docker-apply-prod.yml
@@ -32,7 +32,7 @@ jobs:
     - name: configure aws credentials using OIDC
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:
-        role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-apply 
+        role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-release 
         role-session-name: PushContainer
         aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/docker-apply-prod.yml
+++ b/.github/workflows/docker-apply-prod.yml
@@ -1,17 +1,14 @@
+name: Docker build and push Production
 
-name: Docker build and push
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "docker/**"
-      - ".github/workflows/docker-apply.yml"
+  release:
+    types:
+    - published
 
 env: 
   AWS_REGION: ca-central-1
   REGISTRY: ${{ vars.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/superset
-  GITHUB_SHA: ${{ github.sha }}
+  TAG_VERSION: ${{ github.ref_name }}
 
 permissions:
   id-token: write
@@ -19,7 +16,6 @@ permissions:
   
 jobs:
   docker-push:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
     - name: Audit DNS requests
@@ -49,12 +45,12 @@ jobs:
       run: |
         docker build \
         --file ./docker/Dockerfile \
-        --tag $REGISTRY:sha-$GITHUB_SHA \
+        --tag $REGISTRY:${{ env.TAG_VERSION }} \
         --tag $REGISTRY:latest ./docker
 
     - name: Push Container to Amazon ECR
       run: |
-        docker push $REGISTRY:sha-$GITHUB_SHA
+        docker push $REGISTRY:${{ env.TAG_VERSION }}
         docker push $REGISTRY:latest
 
     - name: Docker generate SBOM

--- a/.github/workflows/docker-apply-staging.yml
+++ b/.github/workflows/docker-apply-staging.yml
@@ -1,0 +1,68 @@
+name: Docker build and push Staging
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docker/**"
+      - ".github/workflows/docker-apply-staging.yml"
+
+env: 
+  AWS_REGION: ca-central-1
+  REGISTRY: ${{ vars.STAGING_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/superset
+  GITHUB_SHA: ${{ github.sha }}
+
+permissions:
+  id-token: write
+  contents: write
+  
+jobs:
+  docker-push:
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Audit DNS requests
+      uses: cds-snc/dns-proxy-action@main
+      env:
+        DNS_PROXY_FORWARDTOSENTINEL: "true"
+        DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+        DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
+
+    - name: Checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    # TODO: Replace with a locked down IAM role
+    - name: configure aws credentials using OIDC
+      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+      with:
+        role-to-assume: arn:aws:iam::${{ vars.STAGING_AWS_ACCOUNT_ID }}:role/cds-superset-apply 
+        role-session-name: PushContainer
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1 
+  
+    - name: Build container
+      working-directory: ./
+      run: |
+        docker build \
+        --file ./docker/Dockerfile \
+        --tag $REGISTRY:sha-$GITHUB_SHA \
+        --tag $REGISTRY:latest ./docker
+
+    - name: Push Container to Amazon ECR
+      run: |
+        docker push $REGISTRY:sha-$GITHUB_SHA
+        docker push $REGISTRY:latest
+
+    - name: Docker generate SBOM
+      uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+      env:
+        TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
+      with:
+        docker_image: "${{ env.REGISTRY }}:latest"
+        dockerfile_path: "./docker/Dockerfile"
+        sbom_name: "cds-superset"
+        token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/docker-deploy-prod.yml
+++ b/.github/workflows/docker-deploy-prod.yml
@@ -1,0 +1,74 @@
+name: Docker deploy Production
+
+on:
+  workflow_run:
+    workflows: ["Docker build and push Production"]
+    types:
+    - completed
+
+env: 
+  AWS_REGION: ca-central-1
+  ECS_CLUSTER: superset
+  REGISTRY: ${{ vars.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/superset
+  GITHUB_SHA: ${{ github.sha }}
+
+permissions:
+  id-token: write
+
+jobs:
+  docker-deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service:
+          - superset
+          - celery-worker
+          - celery-beat
+    steps:
+    - name: Audit DNS requests
+      uses: cds-snc/dns-proxy-action@main
+      env:
+        DNS_PROXY_FORWARDTOSENTINEL: "true"
+        DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+        DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
+
+    # TODO: Replace with a locked down IAM role
+    - name: configure aws credentials using OIDC
+      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+      with:
+        role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-apply 
+        role-session-name: DeployContainer
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Download ECS task definition
+      run: |
+        aws ecs describe-task-definition \
+          --task-definition ${{ matrix.service }} \
+          --query taskDefinition > task-definition.json
+
+    - name: Update ECS task image
+      id: task-def
+      uses: aws-actions/amazon-ecs-render-task-definition@469db592f4341616e992bf7f231e19b3ab9b4efa # v1.6.1
+      with:
+        task-definition: task-definition.json
+        container-name: ${{ matrix.service }}
+        image: ${{ env.REGISTRY }}:${{ github.event.workflow_run.head_branch }}
+
+    - name: Deploy updated ECS task
+      uses: aws-actions/amazon-ecs-deploy-task-definition@135af6c0ea24f888dcaad892bce3b31cc9e5da64 # v2.1.2
+      with:
+        task-definition: ${{ steps.task-def.outputs.task-definition }}
+        service: ${{ matrix.service }}
+        cluster: ${{ env.ECS_CLUSTER }}
+        wait-for-service-stability: true
+
+    - name: Run Superset database upgrade
+      if: ${{ matrix.service == 'superset' }}
+      run: |
+        aws ecs run-task \
+          --cluster ${{ env.ECS_CLUSTER }} \
+          --task-definition superset-upgrade \
+          --launch-type FARGATE \
+          --count 1 \
+          --network-configuration "awsvpcConfiguration={subnets=[${{ secrets.PROD_SUPERSET_PRIVATE_SUBNET_IDS }}],securityGroups=[${{ secrets.PROD_SUPERSET_ECS_TASK_SECURITY_GROUP_ID }}],assignPublicIp=DISABLED}"

--- a/.github/workflows/docker-deploy-staging.yml
+++ b/.github/workflows/docker-deploy-staging.yml
@@ -1,15 +1,15 @@
-name: Docker deploy
+name: Docker deploy Staging
 
 on:
   workflow_run:
-    workflows: ["Docker build and push"]
+    workflows: ["Docker build and push Staging"]
     types:
     - completed
 
 env: 
   AWS_REGION: ca-central-1
   ECS_CLUSTER: superset
-  REGISTRY: ${{ vars.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/superset
+  REGISTRY: ${{ vars.STAGING_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/superset
   GITHUB_SHA: ${{ github.sha }}
 
 permissions:
@@ -37,7 +37,7 @@ jobs:
     - name: configure aws credentials using OIDC
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:
-        role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-apply 
+        role-to-assume: arn:aws:iam::${{ vars.STAGING_AWS_ACCOUNT_ID }}:role/cds-superset-apply 
         role-session-name: DeployContainer
         aws-region: ${{ env.AWS_REGION }}
 
@@ -71,4 +71,4 @@ jobs:
           --task-definition superset-upgrade \
           --launch-type FARGATE \
           --count 1 \
-          --network-configuration "awsvpcConfiguration={subnets=[${{ secrets.SUPERSET_PRIVATE_SUBNET_IDS }}],securityGroups=[${{ secrets.SUPERSET_ECS_TASK_SECURITY_GROUP_ID }}],assignPublicIp=DISABLED}"
+          --network-configuration "awsvpcConfiguration={subnets=[${{ secrets.STAGING_SUPERSET_PRIVATE_SUBNET_IDS }}],securityGroups=[${{ secrets.STAGING_SUPERSET_ECS_TASK_SECURITY_GROUP_ID }}],assignPublicIp=DISABLED}"

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -3,6 +3,7 @@ name: Docker Pull Request
 on:
   pull_request:
     paths:
+      - "version.txt"
       - "docker/**"
       - ".github/workflows/docker-pr.yml"
 

--- a/.github/workflows/tf-apply-prod.yml
+++ b/.github/workflows/tf-apply-prod.yml
@@ -1,15 +1,9 @@
 name: Terraform Apply Production
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "terragrunt/aws/**"
-      - "terragrunt/env/prod/**"
-      - "terragrunt/env/common/**"
-      - "terragrunt/env/terragrunt.hcl"
-      - ".github/workflows/tf-apply-prod.yml"
+  release:
+    types:
+    - published
 
 env:
   AWS_REGION: ca-central-1
@@ -28,8 +22,6 @@ permissions:
 
 jobs:
   terragrunt-apply:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-
     runs-on: ubuntu-latest
     steps:
 

--- a/.github/workflows/tf-apply-prod.yml
+++ b/.github/workflows/tf-apply-prod.yml
@@ -41,7 +41,7 @@ jobs:
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
-          role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-apply 
+          role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-release
           role-session-name: TFApply
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/tf-plan-prod.yml
+++ b/.github/workflows/tf-plan-prod.yml
@@ -1,12 +1,11 @@
 name: Terraform Plan Production
+
 on:
   pull_request:
+    branches:
+      - main
     paths:
-      - "terragrunt/aws/**"
-      - "terragrunt/env/prod/**"
-      - "terragrunt/env/common/**"
-      - "terragrunt/env/terragrunt.hcl"
-      - ".github/workflows/tf-plan-prod.yml"
+      - "version.txt"
 
 env:
   AWS_REGION: ca-central-1

--- a/.github/workflows/workflow-failure.yml
+++ b/.github/workflows/workflow-failure.yml
@@ -1,0 +1,24 @@
+name: Workflow failure
+
+on:
+  workflow_run:
+    workflows:
+      - "Docker deploy Production"
+      - "Docker deploy Staging"
+      - "Docker build and push Production"
+      - "Docker build and push Staging"
+      - "Release Please"
+      - "Terraform Apply Production"
+      - "Terraform Apply Staging"
+    types:
+      - completed
+
+jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+    steps:
+      - name: Notify Slack
+        run: |
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Superset workflow failed: <${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}}]}'
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.PROD_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}


### PR DESCRIPTION
# Summary
Update the Production Docker and Terraform workflows to trigger when a release is published.  The Staging workflows will continue to trigger on pushes to `main`.

Add a workflow failure notifier so we get notified when a workflow has an error.

# Related
- https://github.com/cds-snc/platform-core-services/issues/617