### PR TITLE
fix: release please to trigger release for chore commits

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,20 @@
       "pull-request-title-pattern": "chore: Superset release v${version}"
     }
   },
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "feature", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "revert", "section": "Reverts", "hidden": true },
+    { "type": "docs", "section": "Documentation" },
+    { "type": "style", "section": "Styles" },
+    { "type": "chore", "section": "Miscellaneous Chores" },
+    { "type": "refactor", "section": "Code Refactoring" },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "build", "section": "Build System", "hidden": true },
+    { "type": "ci", "section": "Continuous Integration", "hidden": true }
+  ],
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
# Summary
Update the release please config so that `chore` commits trigger the release process.

# Related
- https://github.com/cds-snc/platform-core-services/issues/617