### PR TITLE
feat!: switch to Aurora Serverless database

### DIFF
--- a/terragrunt/aws/database.tf
+++ b/terragrunt/aws/database.tf
@@ -17,6 +17,9 @@ module "superset_db" {
   preferred_backup_window      = "02:00-04:00"
   performance_insights_enabled = true
 
+  serverless_min_capacity = var.superset_database_min_capacity
+  serverless_max_capacity = var.superset_database_max_capacity
+
   vpc_id             = module.vpc.vpc_id
   subnet_ids         = module.vpc.private_subnet_ids
   security_group_ids = [aws_security_group.superset_db.id]

--- a/terragrunt/aws/variables.tf
+++ b/terragrunt/aws/variables.tf
@@ -26,6 +26,16 @@ variable "superset_database_instance_class" {
   type        = string
 }
 
+variable "superset_database_max_capacity" {
+  description = "The maximum capacity for the serverless database."
+  type        = number
+}
+
+variable "superset_database_min_capacity" {
+  description = "The minimum capacity for the serverless database."
+  type        = number
+}
+
 variable "superset_database_username" {
   description = "The username to use for the database."
   type        = string

--- a/terragrunt/env/prod/terragrunt.hcl
+++ b/terragrunt/env/prod/terragrunt.hcl
@@ -7,6 +7,8 @@ include {
 }
 
 inputs = {
-  superset_database_instance_class  = "db.t3.medium"
-  superset_database_instances_count = 2
+  superset_database_instance_class  = "db.serverless"
+  superset_database_instances_count = 1
+  superset_database_min_capacity    = 1
+  superset_database_max_capacity    = 4
 }

--- a/terragrunt/env/staging/terragrunt.hcl
+++ b/terragrunt/env/staging/terragrunt.hcl
@@ -7,6 +7,8 @@ include {
 }
 
 inputs = {
-  superset_database_instance_class  = "db.t3.medium"
+  superset_database_instance_class  = "db.serverless"
   superset_database_instances_count = 1
+  superset_database_min_capacity    = 1
+  superset_database_max_capacity    = 4
 }


### PR DESCRIPTION
# Summary
Change from provisioned database instances to a serverless instances. This will save cost and allow us to scale with use.

For now, we will run using a single writer instance to see how performance is.