### PR TITLE
chore: suppress DML not allowed CloudWatch errors

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -10,6 +10,7 @@ locals {
   ]
   superset_error_filters_skip = [
     "'Template' object has no attribute 'strip'",
+    "DML_NOT_ALLOWED_ERROR",
     "Error on OAuth authorize",
     "Failed to execute query",
     "GENERIC_DB_ENGINE_ERROR",


### PR DESCRIPTION
# Summary
Update the CloudWatch `ERROR` alarm filter to ignore "DML not allowed" errors.  These are caused by user entered queries and do not require our attention as the error message displayed to the user is clear:

```
superset.exceptions.SupersetErrorsException: [SupersetError(message='This database does not allow for DDL/DML, and the query could not be parsed to confirm it is a read-only query. Please contact your administrator for more assistance.', error_type=<SupersetErrorType.DML_NOT_ALLOWED_ERROR: 'DML_NOT_ALLOWED_ERROR'>, level=<ErrorLevel.ERROR: 'error'>, extra={'issue_codes': [{'code': 1022, 'message': 'Issue 1022 - Database does not allow data manipulation.'}]})]
```