### PR TITLE
fix: remove SBOM generate for prod release

### DIFF
--- a/.github/workflows/docker-apply-prod.yml
+++ b/.github/workflows/docker-apply-prod.yml
@@ -52,13 +52,3 @@ jobs:
       run: |
         docker push $REGISTRY:${{ env.TAG_VERSION }}
         docker push $REGISTRY:latest
-
-    - name: Docker generate SBOM
-      uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
-      env:
-        TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
-      with:
-        docker_image: "${{ env.REGISTRY }}:latest"
-        dockerfile_path: "./docker/Dockerfile"
-        sbom_name: "cds-superset"
-        token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
# Summary
The SBOM generated for the production release is not required as GitHub does not consider its results since it is created for a tag and not the default branch.

The most recent dependency graph will always be updated with every merge to `main` that includes Docker changes.
