### PR TITLE
chore: update to latest Terraform and use lockfile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 			"installTools": false
 		},	
 		"ghcr.io/devcontainers/features/terraform:1": {
-			"version": "1.8.2",
+			"version": "1.10.3",
 			"tflint": "latest",
 			"terragrunt": "0.58.3"
 		}

--- a/.github/workflows/tf-apply-prod.yml
+++ b/.github/workflows/tf-apply-prod.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.8.2
+  TERRAFORM_VERSION: 1.10.3
   TERRAGRUNT_VERSION: 0.58.3
   TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.PROD_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
   TF_VAR_google_oauth_client_id: ${{ secrets.PROD_GOOGLE_OAUTH_CLIENT_ID }}

--- a/.github/workflows/tf-apply-staging.yml
+++ b/.github/workflows/tf-apply-staging.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.8.2
+  TERRAFORM_VERSION: 1.10.3
   TERRAGRUNT_VERSION: 0.58.3
   TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.STAGING_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
   TF_VAR_google_oauth_client_id: ${{ secrets.STAGING_GOOGLE_OAUTH_CLIENT_ID }}

--- a/.github/workflows/tf-plan-prod.yml
+++ b/.github/workflows/tf-plan-prod.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.8.2
+  TERRAFORM_VERSION: 1.10.3
   TERRAGRUNT_VERSION: 0.58.3
   TF_SUMMARIZE_VERSION: 0.3.5
   TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.PROD_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}

--- a/.github/workflows/tf-plan-staging.yml
+++ b/.github/workflows/tf-plan-staging.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.8.2
+  TERRAFORM_VERSION: 1.10.3
   TERRAGRUNT_VERSION: 0.58.3
   TF_SUMMARIZE_VERSION: 0.3.5
   TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.STAGING_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}

--- a/terragrunt/env/terragrunt.hcl
+++ b/terragrunt/env/terragrunt.hcl
@@ -23,7 +23,7 @@ remote_state {
   config = {
     encrypt             = true
     bucket              = "${local.billing_code}-tf"
-    dynamodb_table      = "terraform-state-lock-dynamo"
+    use_lockfile        = true
     region              = "ca-central-1"
     key                 = "./terraform.tfstate"
     s3_bucket_tags      = { CostCenter : local.billing_code }


### PR DESCRIPTION
# Summary
Upgrade Terraform and switch to the new `.tflock` file to manage state locking rather than a DynamoDB table.