### PR TITLE
chore: suppress user query CloudWatch alarms

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -10,6 +10,7 @@ locals {
   ]
   superset_error_filters_skip = [
     "'Template' object has no attribute 'strip'",
+    "COLUMN_NOT_FOUND",
     "DML_NOT_ALLOWED_ERROR",
     "Error on OAuth authorize",
     "Failed to execute query",


### PR DESCRIPTION
# Summary
Update the `ERROR` alarm filter to ignore errors caused by a user writing and testing queries.