### PR TITLE
feat: enable Jinja templating in queries

### DIFF
--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -141,6 +141,10 @@ WTF_CSRF_EXEMPT_LIST = [
 SQLLAB_CTAS_NO_LIMIT = True
 SIP_15_ENABLED = True
 
+FEATURE_FLAGS = {
+    "ENABLE_TEMPLATE_PROCESSING": True,
+}
+
 # Custom roles
 FAB_ROLES = {
     "ReadOnly": [


### PR DESCRIPTION
# Summary
Allow for the use of defined Jinja variables and templating in SQL Labs.
https://superset.apache.org/docs/configuration/sql-templating/