### PR TITLE
feat: create IAM role per Glue database

### DIFF
--- a/terragrunt/aws/athena_iam.tf
+++ b/terragrunt/aws/athena_iam.tf
@@ -5,28 +5,16 @@ locals {
   data_lake_athena_bucket_arn      = "arn:aws:s3:::cds-data-lake-athena-production"
   data_lake_curated_bucket_arn     = "arn:aws:s3:::cds-data-lake-curated-production"
   data_lake_transformed_bucket_arn = "arn:aws:s3:::cds-data-lake-transformed-production"
-
-  glue_base_access = [
-    aws_athena_data_catalog.data_lake.arn,
-    "arn:aws:glue:${local.data_lake_region}:${local.data_lake_account_id}:catalog",
-    "arn:aws:glue:${local.data_lake_region}:${local.data_lake_account_id}:database/operations_aws_production",
-    "arn:aws:glue:${local.data_lake_region}:${local.data_lake_account_id}:table/operations_aws_production/*"
-  ]
-  glue_staging_access = [
-    "arn:aws:glue:${local.data_lake_region}:${local.data_lake_account_id}:database/platform_gc_forms_production",
-    "arn:aws:glue:${local.data_lake_region}:${local.data_lake_account_id}:table/platform_gc_forms_production/*",
-  ]
-  glue_access = concat(local.glue_base_access, (var.env == "staging" ? local.glue_staging_access : []))
 }
 
 resource "aws_iam_role" "superset_athena_read" {
-  name               = "SupersetAthenaRead"
-  description        = "This role allows the Superset ECS task to read from Athena as a datasource"
+  for_each = toset(var.glue_databases)
+
+  name               = "SupersetAthenaRead-${each.key}"
+  description        = "This role allows the Superset ECS task to read from Athena's Glue catalog ${each.key} database"
   assume_role_policy = data.aws_iam_policy_document.superset_ecs_task_role.json
 
-  tags = {
-    Terraform = "true"
-  }
+  tags = local.common_tags
 }
 
 data "aws_iam_policy_document" "superset_ecs_task_role" {
@@ -42,12 +30,21 @@ data "aws_iam_policy_document" "superset_ecs_task_role" {
 }
 
 resource "aws_iam_policy" "superset_athena_read" {
-  name   = "SupersetAthenaRead"
-  policy = data.aws_iam_policy_document.superset_athena_read.json
+  for_each = toset(var.glue_databases)
 
-  tags = {
-    Terraform = "true"
-  }
+  name   = "SupersetAthenaRead-${each.key}"
+  policy = data.aws_iam_policy_document.superset_athena_read_combined[each.key].json
+
+  tags = local.common_tags
+}
+
+data "aws_iam_policy_document" "superset_athena_read_combined" {
+  for_each = toset(var.glue_databases)
+
+  source_policy_documents = [
+    data.aws_iam_policy_document.superset_athena_read.json,
+    data.aws_iam_policy_document.glue_database[each.key].json
+  ]
 }
 
 data "aws_iam_policy_document" "superset_athena_read" {
@@ -91,23 +88,6 @@ data "aws_iam_policy_document" "superset_athena_read" {
   }
 
   statement {
-    sid    = "GlueRead"
-    effect = "Allow"
-    actions = [
-      "glue:BatchGetPartition",
-      "glue:GetDatabase",
-      "glue:GetDatabases",
-      "glue:GetPartition",
-      "glue:GetPartitions",
-      "glue:GetTable",
-      "glue:GetTables",
-      "glue:GetTableVersion",
-      "glue:GetTableVersions"
-    ]
-    resources = local.glue_access
-  }
-
-  statement {
     sid    = "S3AthenaSourceBucketRead"
     effect = "Allow"
     actions = [
@@ -140,7 +120,39 @@ data "aws_iam_policy_document" "superset_athena_read" {
   }
 }
 
+data "aws_iam_policy_document" "glue_database" {
+  for_each = toset(var.glue_databases)
+
+  statement {
+    sid    = "GlueRead-${each.key}"
+    effect = "Allow"
+    actions = [
+      "glue:BatchGetPartition",
+      "glue:GetDatabase",
+      "glue:GetDatabases",
+      "glue:GetPartition",
+      "glue:GetPartitions",
+      "glue:GetTable",
+      "glue:GetTables",
+      "glue:GetTableVersion",
+      "glue:GetTableVersions"
+    ]
+    resources = concat(
+      [
+        aws_athena_data_catalog.data_lake.arn,
+        "arn:aws:glue:${local.data_lake_region}:${local.data_lake_account_id}:catalog",
+      ],
+      [
+        "arn:aws:glue:${local.data_lake_region}:${local.data_lake_account_id}:database/${each.key}",
+        "arn:aws:glue:${local.data_lake_region}:${local.data_lake_account_id}:table/${each.key}/*"
+      ]
+    )
+  }
+}
+
 resource "aws_iam_role_policy_attachment" "superset_athena_read" {
-  policy_arn = aws_iam_policy.superset_athena_read.arn
-  role       = aws_iam_role.superset_athena_read.name
+  for_each = toset(var.glue_databases)
+
+  policy_arn = aws_iam_policy.superset_athena_read[each.key].arn
+  role       = aws_iam_role.superset_athena_read[each.key].name
 }

--- a/terragrunt/aws/variables.tf
+++ b/terragrunt/aws/variables.tf
@@ -4,6 +4,11 @@ variable "cloudwatch_alert_slack_webhook" {
   sensitive   = true
 }
 
+variable "glue_databases" {
+  description = "List of Glue databases to grant access to."
+  type        = list(string)
+}
+
 variable "google_oauth_client_id" {
   description = "Google OAuth client ID to enable logging in with Google."
   type        = string

--- a/terragrunt/env/prod/terragrunt.hcl
+++ b/terragrunt/env/prod/terragrunt.hcl
@@ -7,6 +7,9 @@ include {
 }
 
 inputs = {
+  glue_databases = [
+    "operations_aws_production",
+  ]
   superset_database_instance_class  = "db.serverless"
   superset_database_instances_count = 1
   superset_database_min_capacity    = 1

--- a/terragrunt/env/staging/terragrunt.hcl
+++ b/terragrunt/env/staging/terragrunt.hcl
@@ -7,6 +7,10 @@ include {
 }
 
 inputs = {
+  glue_databases = [
+    "platform_gc_forms_production",
+    "operations_aws_production",
+  ]
   superset_database_instance_class  = "db.serverless"
   superset_database_instances_count = 1
   superset_database_min_capacity    = 1


### PR DESCRIPTION
# Summary
Add a dedicated IAM role that is used by Superset to connect to each AWS Glue database.  This is being done to give us finer control over which databases are visible to a user.

# Related
- https://github.com/cds-snc/platform-core-services/issues/649
- https://github.com/cds-snc/data-lake/pull/71