### PR TITLE
fix: non-alpha characters in IAM policy sid

### DIFF
--- a/terragrunt/aws/athena_iam.tf
+++ b/terragrunt/aws/athena_iam.tf
@@ -124,7 +124,7 @@ data "aws_iam_policy_document" "glue_database" {
   for_each = toset(var.glue_databases)
 
   statement {
-    sid    = "GlueRead-${each.key}"
+    sid    = "GlueRead"
     effect = "Allow"
     actions = [
       "glue:BatchGetPartition",


### PR DESCRIPTION
# Summary
Update the GlueRead IAM policy so that its `sid` attribute does not contain non alphanumeric characters.

⚠️ This was applied locally to test.

# Related
- https://github.com/cds-snc/platform-core-services/issues/649