### PR TITLE
fix: remove suppress of generic DB errors

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -14,7 +14,6 @@ locals {
     "DML_NOT_ALLOWED_ERROR",
     "Error on OAuth authorize",
     "Failed to execute query",
-    "GENERIC_DB_ENGINE_ERROR",
     "SYNTAX_ERROR"
   ]
   superset_error_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.superset_error_filters)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.superset_error_filters_skip)}*\"]"


### PR DESCRIPTION
# Summary
We're seeing cases were non-user related actions are causing this error to be thrown by Superset.  For example, the following is thrown when a query consumes too much memory:

```
superset.exceptions.SupersetErrorsException: [SupersetError(message="command not allowed when used memory > 'maxmemory'.", error_type=<SupersetErrorType.GENERIC_DB_ENGINE_ERROR: 'GENERIC_DB_ENGINE_ERROR'>, level=<ErrorLevel.ERROR: 'error'>, extra={'engine_name': 'Amazon Athena', 'issue_codes': [{'code': 1002, 'message': 'Issue 1002 - The database returned an unexpected error.'}]})]
```

As a result, we'll remove the generic suppression and re-add user-related error suppressions as they come up.

# Related
- https://github.com/cds-snc/platform-core-services/issues/657
