### PR TITLE
chore: suppress AccessDenied DB errors

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -10,6 +10,7 @@ locals {
   ]
   superset_error_filters_skip = [
     "'Template' object has no attribute 'strip'",
+    "AccessDenied*GENERIC_DB_ENGINE_ERROR",
     "COLUMN_NOT_FOUND",
     "DML_NOT_ALLOWED_ERROR",
     "Error on OAuth authorize",


### PR DESCRIPTION
# Summary
These AccessDenied database errors are caused by a user attempting to query a Glue database table they do not have access to.