### PR TITLE
chore: suppress user generated error

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -15,6 +15,7 @@ locals {
     "DML_NOT_ALLOWED_ERROR",
     "Error on OAuth authorize",
     "Failed to execute query",
+    "Only `SELECT` statements are allowed",
     "SYNTAX_ERROR"
   ]
   superset_error_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.superset_error_filters)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.superset_error_filters_skip)}*\"]"


### PR DESCRIPTION
# Summary
Suppress CloudWatch alarm for user attempting to run a non SELECT statement in the SQL Lab editor.