### PR TITLE
feat: onboard Freshdesk dataset to prod

### DIFF
--- a/terragrunt/env/prod/terragrunt.hcl
+++ b/terragrunt/env/prod/terragrunt.hcl
@@ -10,6 +10,7 @@ inputs = {
   glue_databases = [
     "all",
     "operations_aws_production",
+    "platform_support_production",
   ]
   superset_database_instance_class  = "db.serverless"
   superset_database_instances_count = 1


### PR DESCRIPTION
# Summary
Allow Superset prod to access the Freshdesk dataset.

⚠️  It is expected that there are no changes as this only applies to the production environment.

# Related
- https://github.com/cds-snc/platform-core-services/issues/621