### PR TITLE
fix: add missing `explore` permissions to ReadOnly role

### DIFF
--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -185,6 +185,8 @@ FAB_ROLES = {
         ["SqlLab", "can_my_queries"],
         ["Superset", "can_dashboard"],
         ["Superset", "can_dashboard_permalink"],
+        ["Superset", "can_explore"],
+        ["Superset", "can_explore_json"],
         ["Superset", "can_log"],
         ["Superset", "can_profile"],
         ["Superset", "can_share_chart"],


### PR DESCRIPTION
# Summary
Update the ReadOnly role to include the explore permissions required to view and interact with calendar heatmap charts.

![image](https://github.com/user-attachments/assets/c779c027-02dd-4be6-844e-8a3302cbc935)


# Related
- https://github.com/apache/superset/discussions/30542