### PR TITLE
chore: suppress user query error

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -15,6 +15,7 @@ locals {
     "DML_NOT_ALLOWED_ERROR",
     "Error on OAuth authorize",
     "Failed to execute query",
+    "Insufficient permissions to execute the query",
     "Only `SELECT` statements are allowed",
     "SYNTAX_ERROR"
   ]


### PR DESCRIPTION
# Summary
Suppress the error a user receives when they run a SQL labs query without selecting the proper database.
