### PR TITLE
chore: suppress user query errors

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -12,6 +12,7 @@ locals {
     "'Template' object has no attribute 'strip'",
     "AccessDenied*GENERIC_DB_ENGINE_ERROR",
     "COLUMN_NOT_FOUND",
+    "contains non-numeric values",
     "DML_NOT_ALLOWED_ERROR",
     "Error on OAuth authorize",
     "Failed to execute query",


### PR DESCRIPTION
# Summary
Suppress CloudWatch alarms for the following recoverable user error:
```
Column 'field_name' contains non-numeric values
```
