### PR TITLE
feat: add SNS alarm topics in us-east-1

### DIFF
--- a/terragrunt/aws/kms.tf
+++ b/terragrunt/aws/kms.tf
@@ -9,6 +9,16 @@ resource "aws_kms_key" "cloudwatch_alerts" {
   tags = local.common_tags
 }
 
+resource "aws_kms_key" "cloudwatch_alerts_us_east_1" {
+  provider = aws.us_east_1
+
+  description         = "SNS topic for CloudWatch alarm alerts"
+  enable_key_rotation = true
+  policy              = data.aws_iam_policy_document.kms_cloudwatch.json
+
+  tags = local.common_tags
+}
+
 data "aws_iam_policy_document" "kms_cloudwatch" {
   # checkov:skip=CKV_AWS_109: `resources = ["*"]` identifies the KMS key to which the key policy is attached
   # checkov:skip=CKV_AWS_111: `resources = ["*"]` identifies the KMS key to which the key policy is attached
@@ -39,6 +49,11 @@ data "aws_iam_policy_document" "kms_cloudwatch" {
     principals {
       type        = "Service"
       identifiers = ["logs.${var.region}.amazonaws.com"]
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.us-east-1.amazonaws.com"]
     }
   }
 

--- a/terragrunt/aws/kms.tf
+++ b/terragrunt/aws/kms.tf
@@ -10,7 +10,7 @@ resource "aws_kms_key" "cloudwatch_alerts" {
 }
 
 resource "aws_kms_key" "cloudwatch_alerts_us_east_1" {
-  provider = aws.us_east_1
+  provider = aws.us-east-1
 
   description         = "SNS topic for CloudWatch alarm alerts"
   enable_key_rotation = true

--- a/terragrunt/aws/sns.tf
+++ b/terragrunt/aws/sns.tf
@@ -13,6 +13,22 @@ resource "aws_sns_topic" "cloudwatch_alert_ok" {
   tags              = local.common_tags
 }
 
+resource "aws_sns_topic" "cloudwatch_alert_warning_us_east_1" {
+  provider = aws.us-east-1
+
+  name              = "cloudwatch-alert-warning"
+  kms_master_key_id = aws_kms_key.cloudwatch_alerts_us_east_1.arn
+  tags              = local.common_tags
+}
+
+resource "aws_sns_topic" "cloudwatch_alert_ok_us_east_1" {
+  provider = aws.us-east-1
+
+  name              = "cloudwatch-alert-ok"
+  kms_master_key_id = aws_kms_key.cloudwatch_alerts_us_east_1.arn
+  tags              = local.common_tags
+}
+
 #
 # SNS topic subscriptions
 #
@@ -28,6 +44,22 @@ resource "aws_sns_topic_subscription" "cloudwatch_alert_ok" {
   endpoint  = var.cloudwatch_alert_slack_webhook
 }
 
+resource "aws_sns_topic_subscription" "cloudwatch_alert_warning_us_east_1" {
+  provider = aws.us-east-1
+
+  topic_arn = aws_sns_topic.cloudwatch_alert_warning_us_east_1.arn
+  protocol  = "https"
+  endpoint  = var.cloudwatch_alert_slack_webhook
+}
+
+resource "aws_sns_topic_subscription" "cloudwatch_alert_ok_us_east_1" {
+  provider = aws.us-east-1
+
+  topic_arn = aws_sns_topic.cloudwatch_alert_ok_us_east_1.arn
+  protocol  = "https"
+  endpoint  = var.cloudwatch_alert_slack_webhook
+}
+
 #
 # Allow CloudWatch to use the SNS topics
 #
@@ -38,6 +70,20 @@ resource "aws_sns_topic_policy" "cloudwatch_alert_warning" {
 
 resource "aws_sns_topic_policy" "cloudwatch_alert_ok" {
   arn    = aws_sns_topic.cloudwatch_alert_ok.arn
+  policy = data.aws_iam_policy_document.cloudwatch_events_sns_topic.json
+}
+
+resource "aws_sns_topic_policy" "cloudwatch_alert_warning_us_east_1" {
+  provider = aws.us-east-1
+
+  arn    = aws_sns_topic.cloudwatch_alert_warning_us_east_1.arn
+  policy = data.aws_iam_policy_document.cloudwatch_events_sns_topic.json
+}
+
+resource "aws_sns_topic_policy" "cloudwatch_alert_ok_us_east_1" {
+  provider = aws.us-east-1
+
+  arn    = aws_sns_topic.cloudwatch_alert_ok_us_east_1.arn
   policy = data.aws_iam_policy_document.cloudwatch_events_sns_topic.json
 }
 


### PR DESCRIPTION
# Summary
Add new SNS topics to handle alarm notifications
in `us-east-1`.

# Related
- https://github.com/cds-snc/platform-core-services/issues/667