### PR TITLE
fix: update CA geo restriction with Upptime header

### DIFF
--- a/.github/workflows/tf-apply-prod.yml
+++ b/.github/workflows/tf-apply-prod.yml
@@ -15,6 +15,7 @@ env:
   TF_VAR_superset_database_username: ${{ secrets.PROD_SUPERSET_DATABASE_USERNAME }}
   TF_VAR_superset_database_password: ${{ secrets.PROD_SUPERSET_DATABASE_PASSWORD }}
   TF_VAR_superset_secret_key: ${{ secrets.PROD_SUPERSET_SECRET_KEY }}
+  TF_VAR_upptime_status_header: ${{ secrets.PROD_UPPTIME_STATUS_HEADER }}
   
 permissions:
   id-token: write

--- a/.github/workflows/tf-apply-staging.yml
+++ b/.github/workflows/tf-apply-staging.yml
@@ -21,6 +21,7 @@ env:
   TF_VAR_superset_database_username: ${{ secrets.STAGING_SUPERSET_DATABASE_USERNAME }}
   TF_VAR_superset_database_password: ${{ secrets.STAGING_SUPERSET_DATABASE_PASSWORD }}
   TF_VAR_superset_secret_key: ${{ secrets.STAGING_SUPERSET_SECRET_KEY }}
+  TF_VAR_upptime_status_header: ${{ secrets.STAGING_UPPTIME_STATUS_HEADER }}
   
 permissions:
   id-token: write

--- a/.github/workflows/tf-plan-prod.yml
+++ b/.github/workflows/tf-plan-prod.yml
@@ -18,8 +18,8 @@ env:
   TF_VAR_superset_database_username: ${{ secrets.PROD_SUPERSET_DATABASE_USERNAME }}
   TF_VAR_superset_database_password: ${{ secrets.PROD_SUPERSET_DATABASE_PASSWORD }}
   TF_VAR_superset_secret_key: ${{ secrets.PROD_SUPERSET_SECRET_KEY }}
+  TF_VAR_upptime_status_header: ${{ secrets.PROD_UPPTIME_STATUS_HEADER }}
 
-  
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/tf-plan-staging.yml
+++ b/.github/workflows/tf-plan-staging.yml
@@ -19,8 +19,8 @@ env:
   TF_VAR_superset_database_username: ${{ secrets.STAGING_SUPERSET_DATABASE_USERNAME }}
   TF_VAR_superset_database_password: ${{ secrets.STAGING_SUPERSET_DATABASE_PASSWORD }}
   TF_VAR_superset_secret_key: ${{ secrets.STAGING_SUPERSET_SECRET_KEY }}
+  TF_VAR_upptime_status_header: ${{ secrets.STAGING_UPPTIME_STATUS_HEADER }}
 
-  
 permissions:
   id-token: write
   contents: read

--- a/terragrunt/aws/variables.tf
+++ b/terragrunt/aws/variables.tf
@@ -58,3 +58,9 @@ variable "superset_secret_key" {
   type        = string
   sensitive   = true
 }
+
+variable "upptime_status_header" {
+  description = "The header to check for Upptime status check requests."
+  type        = string
+  sensitive   = true
+}

--- a/terragrunt/aws/waf.tf
+++ b/terragrunt/aws/waf.tf
@@ -54,7 +54,7 @@ resource "aws_wafv2_web_acl" "superset" {
   }
 
   rule {
-    name     = "CanadaOnlyGeoRestriction"
+    name     = "GeoRestriction"
     priority = 5
 
     action {
@@ -63,7 +63,7 @@ resource "aws_wafv2_web_acl" "superset" {
           response_code = 403
           response_header {
             name  = "waf-block"
-            value = "CanadaOnlyGeoRestriction"
+            value = "GeoRestriction"
           }
         }
       }
@@ -73,7 +73,7 @@ resource "aws_wafv2_web_acl" "superset" {
       not_statement {
         statement {
           geo_match_statement {
-            country_codes = ["CA"]
+            country_codes = ["CA", "US"]
           }
         }
       }
@@ -81,7 +81,7 @@ resource "aws_wafv2_web_acl" "superset" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "CanadaOnlyGeoRestriction"
+      metric_name                = "GeoRestriction"
       sampled_requests_enabled   = true
     }
   }

--- a/terragrunt/aws/waf.tf
+++ b/terragrunt/aws/waf.tf
@@ -54,7 +54,7 @@ resource "aws_wafv2_web_acl" "superset" {
   }
 
   rule {
-    name     = "GeoRestriction"
+    name     = "CanadaOnlyGeoRestriction"
     priority = 5
 
     action {
@@ -63,7 +63,7 @@ resource "aws_wafv2_web_acl" "superset" {
           response_code = 403
           response_header {
             name  = "waf-block"
-            value = "GeoRestriction"
+            value = "CanadaOnlyGeoRestriction"
           }
         }
       }
@@ -72,8 +72,27 @@ resource "aws_wafv2_web_acl" "superset" {
     statement {
       not_statement {
         statement {
-          geo_match_statement {
-            country_codes = ["CA", "US"]
+          or_statement {
+            statement {
+              geo_match_statement {
+                country_codes = ["CA"]
+              }
+            }
+            statement {
+              byte_match_statement {
+                positional_constraint = "EXACTLY"
+                field_to_match {
+                  single_header {
+                    name = "upptime"
+                  }
+                }
+                search_string = var.upptime_status_header
+                text_transformation {
+                  priority = 1
+                  type     = "NONE"
+                }
+              }
+            }
           }
         }
       }
@@ -81,7 +100,7 @@ resource "aws_wafv2_web_acl" "superset" {
 
     visibility_config {
       cloudwatch_metrics_enabled = true
-      metric_name                = "GeoRestriction"
+      metric_name                = "CanadaOnlyGeoRestriction"
       sampled_requests_enabled   = true
     }
   }


### PR DESCRIPTION
# Summary
The status checker's IP address is occasionally being identified as in the US so we're adding a secret Upptime request header that will allow those requests to succeed.