### PR TITLE
fix: add warning CloudWatch alarm

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -17,6 +17,7 @@ locals {
     "Error on OAuth authorize",
     "Error warming up cache",
     "Failed to execute query",
+    "gsheets error: Unsupported format",
     "Insufficient permissions to execute the query",
     "Only `SELECT` statements are allowed",
     "SYNTAX_ERROR",


### PR DESCRIPTION
# Summary
Add a new CloudWatch alarm that triggers if more than a specified threshold of warnings have been reported.

Also adjust the error alarm to suppress more user generated errors.