### PR TITLE
fix: propagate tags on new deployments

### DIFF
--- a/.github/workflows/docker-deploy-prod.yml
+++ b/.github/workflows/docker-deploy-prod.yml
@@ -62,6 +62,7 @@ jobs:
         service: ${{ matrix.service }}
         cluster: ${{ env.ECS_CLUSTER }}
         wait-for-service-stability: true
+        propagate-tags: SERVICE
 
     - name: Run Superset database upgrade
       if: ${{ matrix.service == 'superset' }}

--- a/.github/workflows/docker-deploy-staging.yml
+++ b/.github/workflows/docker-deploy-staging.yml
@@ -62,6 +62,7 @@ jobs:
         service: ${{ matrix.service }}
         cluster: ${{ env.ECS_CLUSTER }}
         wait-for-service-stability: true
+        propagate-tags: SERVICE
 
     - name: Run Superset database upgrade
       if: ${{ matrix.service == 'superset' }}


### PR DESCRIPTION
# Summary
Update the ECS task deployment action so that tags are propagated.

This has been causing a minor Terraform plan filp/flop when Terraform apply is run after this action since it has been unsetting the value.
