### PR TITLE
fix: allow Celery works to perform async queries

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -20,8 +20,11 @@ locals {
     "gsheets error: Unsupported format",
     "Insufficient permissions to execute the query",
     "Only `SELECT` statements are allowed",
+    "sql_lab*Unsupported table",
     "SYNTAX_ERROR",
-    "TABLE_DOES_NOT_EXIST_ERROR"
+    "Table does not exist",
+    "TABLE_DOES_NOT_EXIST_ERROR",
+    "TABLE_NOT_FOUND"
   ]
   superset_error_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.superset_error_filters)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.superset_error_filters_skip)}*\"]"
 

--- a/terragrunt/aws/athena_iam.tf
+++ b/terragrunt/aws/athena_iam.tf
@@ -11,7 +11,7 @@ resource "aws_iam_role" "superset_athena_read" {
   for_each = toset(var.glue_databases)
 
   name               = "SupersetAthenaRead-${each.key}"
-  description        = "This role allows the Superset ECS task to read from ${each.key == "all" ? "all Glue databases" : "the ${each.key} Glue database"}"
+  description        = "This role allows the Superset ECS task and Celery workers to read from ${each.key == "all" ? "all Glue databases" : "the ${each.key} Glue database"}"
   assume_role_policy = data.aws_iam_policy_document.superset_ecs_task_role.json
 
   tags = local.common_tags
@@ -23,7 +23,8 @@ data "aws_iam_policy_document" "superset_ecs_task_role" {
     principals {
       type = "AWS"
       identifiers = [
-        module.superset_ecs.task_role_arn
+        module.superset_ecs.task_role_arn,
+        module.celery_worker_ecs.task_role_arn,
       ]
     }
   }


### PR DESCRIPTION
# Summary
Update the IAM permissions to allow asynchronous queries to be run by the Celery workers.  Currenly, queries can only be run synchronously by the Superset ECS task, which is resulting in performance impacts and slower response times.

Update the CloudWatch alarms to suppress more user generated errors from queries run in SQL labs.
