### PR TITLE
chore: remove the SupersetAthenaReal-all role

### DIFF
--- a/terragrunt/aws/athena_iam.tf
+++ b/terragrunt/aws/athena_iam.tf
@@ -11,7 +11,7 @@ resource "aws_iam_role" "superset_athena_read" {
   for_each = toset(var.glue_databases)
 
   name               = "SupersetAthenaRead-${each.key}"
-  description        = "This role allows the Superset ECS task and Celery workers to read from ${each.key == "all" ? "all Glue databases" : "the ${each.key} Glue database"}"
+  description        = "This role allows the Superset ECS task and Celery workers to read from the ${each.key} Glue database"
   assume_role_policy = data.aws_iam_policy_document.superset_ecs_task_role.json
 
   tags = local.common_tags

--- a/terragrunt/env/prod/terragrunt.hcl
+++ b/terragrunt/env/prod/terragrunt.hcl
@@ -8,7 +8,6 @@ include {
 
 inputs = {
   glue_databases = [
-    "all",
     "operations_aws_production",
     "platform_support_production",
   ]

--- a/terragrunt/env/staging/terragrunt.hcl
+++ b/terragrunt/env/staging/terragrunt.hcl
@@ -8,7 +8,6 @@ include {
 
 inputs = {
   glue_databases = [
-    "all",
     "platform_gc_forms_production",
     "platform_support_production",
     "operations_aws_production",


### PR DESCRIPTION
# Summary
This role is no longer required now that we've setup the Superset Meta Database which allows querying across databases.

# Related
- https://github.com/cds-snc/platform-core-services/issues/689