### PR TITLE
feat: setup superset meta db limit to 10000

### DIFF
--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -148,6 +148,8 @@ FEATURE_FLAGS = {
     "ENABLE_SUPERSET_META_DB": True,
 }
 
+SUPERSET_META_DB_LIMIT = 10000
+
 LANGUAGES = {
     "en": {"flag": "ca", "name": "English"},
     "fr": {"flag": "ca", "name": "Français"},


### PR DESCRIPTION
# Summary | Résumé

Increase row limit for Superset Meta DB to 10k to test larger queries