### PR TITLE
revert: meta database limit to default value

### DIFF
--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -148,7 +148,7 @@ FEATURE_FLAGS = {
     "ENABLE_SUPERSET_META_DB": True,
 }
 
-SUPERSET_META_DB_LIMIT = 100000
+SUPERSET_META_DB_LIMIT = 1000
 
 LANGUAGES = {
     "en": {"flag": "ca", "name": "English"},

--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -20,12 +20,13 @@ locals {
     "gsheets error: Unsupported format",
     "Insufficient permissions to execute the query",
     "Only `SELECT` statements are allowed",
-    "sql_lab*Unsupported table",
+    "SQLError",
     "SYNTAX_ERROR",
     "Table does not exist",
     "TABLE_DOES_NOT_EXIST_ERROR",
     "TABLE_NOT_FOUND",
-    "Unsupported format"
+    "Unsupported format",
+    "Unsupported table"
   ]
   superset_error_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.superset_error_filters)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.superset_error_filters_skip)}*\"]"
 


### PR DESCRIPTION
# Summary
Reduce the Superset meta database limit back to its default value.  This is the number of rows that will be scanned from a table before joining and aggregation occurs (lower = less memory usage).

Update the alarms with a few more user generated error message from SQL labs.
