### PR TITLE
fix: adjust load balancer response time alarm

### DIFF
--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -73,12 +73,12 @@ class CeleryConfig(object):
         },
         "cache-warmup-charts": {
             "task": "cache-warmup",
-            "schedule": crontab(minute=0, hour="*/2"),
+            "schedule": crontab(minute=0, hour="*/12"),
             "kwargs": {"strategy_name": "dummy"},
         },
         "cache-warmup-dashboard": {
             "task": "cache-warmup",
-            "schedule": crontab(minute=5, hour="*/2"),
+            "schedule": crontab(minute=15, hour="*/12"),
             "kwargs": {
                 "strategy_name": "top_n_dashboards",
                 "top_n": 10,

--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -38,7 +38,7 @@ locals {
 
   threshold_ecs_high_cpu     = 80
   threshold_ecs_high_memory  = 80
-  threshold_lb_response_time = 2
+  threshold_lb_response_time = 3
 }
 
 #
@@ -145,10 +145,10 @@ resource "aws_cloudwatch_metric_alarm" "superset_load_balancer_healthy_hosts" {
 
 resource "aws_cloudwatch_metric_alarm" "superset_load_balancer_response_time" {
   alarm_name          = "load-balancer-response-time"
-  alarm_description   = "Response time for the Superset load balancer is greater than 2 seconds over 5 minutes."
+  alarm_description   = "Response time for the Superset load balancer is consistently over 3 seconds over 5 minutes."
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = "5"
-  datapoints_to_alarm = "3"
+  datapoints_to_alarm = "4"
   threshold           = local.threshold_lb_response_time
   treat_missing_data  = "notBreaching"
 


### PR DESCRIPTION
# Summary
Reduce the sensitivity of slow load balancer alarms as these are being caused by the cache warmup requests, which are resource intensive.

As part of this change, the frequency of cache warmups are also being reduced so they occur primarily outside of business hours.  This should not have a large impact as the cache is set to last for 24 hours.
