### PR TITLE
fix: skip integration test for the meta database

### DIFF
--- a/docker/superset/integration_tests/database.py
+++ b/docker/superset/integration_tests/database.py
@@ -23,12 +23,17 @@ def test_access(app):
             logger.info(f"Found {len(databases)} database connections to test")
 
             for database in databases:
-                # Only test databases that are not impersonating the user.  This is done to
-                # skip database connections like Google Sheets that require user permissions
-                # to access the data.
+                # Skip databases that require user impersonation
                 if database.impersonate_user is True:
                     logger.info(
                         f"Skipping database '{database.database_name}' as it requires user impersonation"
+                    )
+                    continue
+
+                # Skip the Superset meta database
+                if database.sqlalchemy_uri == "superset://":
+                    logger.info(
+                        f"Skipping database '{database.database_name}' as it is a meta database"
                     )
                     continue
 


### PR DESCRIPTION
# Summary
Update the integration tests so they no longer try to test Superset meta databases.  This is being done because the meta database tables (datasets) do not behave like regular datasets, which is causing the integration tests to report false-positive failures.