### PR TITLE
fix: Superset ReadOnly and WriteData roles

### DIFF
--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -149,7 +149,7 @@ FEATURE_FLAGS = {
     "ENABLE_SUPERSET_META_DB": True,
     "SQL_VALIDATORS_BY_ENGINE": {
         "presto": "PrestoDBSQLValidator",
-    }
+    },
 }
 
 SUPERSET_META_DB_LIMIT = 1000


### PR DESCRIPTION
# Summary
Reduce the permissions of the default `ReadOnly` role.  We will switch to using Dashboard RBAC to grant this role selective access to dashboards.  

With Dashboard RBAC, we can grant the `ReadOnly` role direct access to specific dashboards without having to give it read access to the underlying datasources. This will then allow us fine-grained control over which datasources a user with the `WriteData` role can create dashboards and charts for.

The is required because while Superset gives granular control to which datasources a user can read, it does not provide the same granularity for writing.  As a result, if a user has read to a datasource AND they have the top level `can write` permission, they can create charts/dashboards for that datasource.

# Related
- https://github.com/cds-snc/platform-core-services/issues/648