### PR TITLE
chore: suppress user generated alarms

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -19,12 +19,14 @@ locals {
     "Failed to execute query",
     "gsheets error: Unsupported format",
     "Insufficient permissions to execute the query",
+    "InvalidRequestException*GENERIC_DB_ENGINE_ERROR",
     "Only `SELECT` statements are allowed",
     "SQLError",
     "SYNTAX_ERROR",
     "Table does not exist",
     "TABLE_DOES_NOT_EXIST_ERROR",
     "TABLE_NOT_FOUND",
+    "TYPE_MISMATCH",
     "Unsupported format",
     "Unsupported table"
   ]


### PR DESCRIPTION
# Summary
Update the list of CloudWatch alarms to suppress caused by user generated SQL query errors.