### PR TITLE
feat: allow some 4XX resonses through the IP blocklist

### DIFF
--- a/terragrunt/aws/waf.tf
+++ b/terragrunt/aws/waf.tf
@@ -482,7 +482,7 @@ data "aws_iam_policy_document" "superset_waf_logs" {
 # that crosses a block threshold will be added to the blocklist.
 #
 module "waf_ip_blocklist" {
-  source = "github.com/cds-snc/terraform-modules//waf_ip_blocklist?ref=v10.4.1"
+  source = "github.com/cds-snc/terraform-modules//waf_ip_blocklist?ref=7b9e797237e37e685ae710a12e4a3963eb7545bb" # v10.4.2
 
   service_name                = "superset"
   athena_database_name        = "access_logs"
@@ -491,6 +491,7 @@ module "waf_ip_blocklist" {
   athena_lb_table_name        = "lb_logs"
   athena_waf_table_name       = "waf_logs"
   athena_workgroup_name       = "primary"
+  lb_status_code_skip         = ["405", "410", "422"]
 
   billing_tag_value = var.billing_code
 }


### PR DESCRIPTION
# Summary
Update the WAF IP blocklist to the latest version up allow 405, 410 and 422 responses from users.  These are returned occasionally by Superset for legitimate requests and should not cause the user's IP to be blocked.
