### PR TITLE
fix: allow CacheWarmer access to all data

### DIFF
--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -176,6 +176,8 @@ FLASK_APP_MUTATOR = app_mutator
 FAB_ROLES = {
     "CacheWarmer": [
         [".*", "can_warm_up_cache"],
+        ["all_database_access", "all_database_access"],
+        ["all_datasource_access", "all_datasource_access"],
     ],
     "PlatformUser": [],
     "ReadOnly": [


### PR DESCRIPTION
# Summary
Update the CacheWarmer role so that it has access to all datasources. Without this, it cannot properly query data and preload the cache.