### PR TITLE
fix: permissions for `WriteData` role

### DIFF
--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -222,6 +222,11 @@ FAB_ROLES = {
         ["Dashboard", "can_write"],
         ["Dataset", "can_write"],
         ["Datasets", "menu_access"],
+        ["TableSchemaView", "can_delete"],
+        ["TableSchemaView", "can_expanded"],
+        ["TableSchemaView", "can_post"],
+        ["TabStateView", "can_delete"],
+        ["TabStateView", "can_post"],
     ],
 }
 


### PR DESCRIPTION
# Summary
Add the ability to manage the TableSchemaView and TabStateView. These missing permissions were resulting in 403 errors to our users trying to create charts and run SQL queries.