### PR TITLE
chore: suppress generic PostgresSQL errors

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -10,16 +10,15 @@ locals {
   ]
   superset_error_filters_skip = [
     "'Template' object has no attribute 'strip'",
-    "AccessDenied*GENERIC_DB_ENGINE_ERROR",
     "COLUMN_NOT_FOUND",
     "contains non-numeric values",
     "DML_NOT_ALLOWED_ERROR",
     "Error on OAuth authorize",
     "Error warming up cache",
     "Failed to execute query",
+    "GENERIC_DB_ENGINE_ERROR",
     "gsheets error: Unsupported format",
     "Insufficient permissions to execute the query",
-    "InvalidRequestException*GENERIC_DB_ENGINE_ERROR",
     "Only `SELECT` statements are allowed",
     "SQLError",
     "SYNTAX_ERROR",

--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -16,6 +16,7 @@ locals {
     "Error on OAuth authorize",
     "Error warming up cache",
     "Failed to execute query",
+    "flask_appbuilder.api:dict is not a sequence",
     "GENERIC_DB_ENGINE_ERROR",
     "gsheets error: Unsupported format",
     "Insufficient permissions to execute the query",


### PR DESCRIPTION
# Summary 
Update the CloudWatch error alarm filters to avoid triggering an alarm for user entered query issues.  This is being done so that when a user it using SQL labs and enters a malformed query, it does not alert our team.

Notes:
- This will suppress CloudWatch alarms for logs with `ERROR` in them if they also contain the string `GENERIC_DB_ENGINE_ERROR`.
- The two existing suppressions that had this string are being removed since they're now covered by this more general case.
- This updates 3 CloudWatch alarms as the filter pattern is shared by the 3 ECS services used to run Superset (`superset`, `celery-worker` and `celery-beat`).