### PR TITLE
fix: add Staging Data Lake IAM roles

### DIFF
--- a/terragrunt/aws/waf.tf
+++ b/terragrunt/aws/waf.tf
@@ -286,7 +286,7 @@ resource "aws_wafv2_web_acl" "superset" {
     priority = 60
 
     action {
-      block {}
+      count {}
     }
 
     statement {

--- a/terragrunt/env/staging/terragrunt.hcl
+++ b/terragrunt/env/staging/terragrunt.hcl
@@ -9,8 +9,11 @@ include {
 inputs = {
   glue_databases = [
     "platform_gc_forms_production",
+    "platform_gc_forms_staging",
     "platform_gc_notify_production",
+    "platform_gc_notify_staging",
     "platform_support_production",
+    "platform_support_staging",
     "operations_aws_production",
     "bes_crm_salesforce_production",
   ]


### PR DESCRIPTION
# Summary
Update the Superset IAM roles to include the Data Lake Staging Glue databases.

Also disables the `block` action on the firewall for the BlockedIP rule as there are still several cases of legitimate users being blocked by this.
