### PR TITLE
fix: Superset IAM roles used to access the Data Lake

### DIFF
--- a/terragrunt/aws/athena_iam.tf
+++ b/terragrunt/aws/athena_iam.tf
@@ -141,12 +141,14 @@ data "aws_iam_policy_document" "glue_database" {
       "glue:GetTableVersions"
     ]
     resources = flatten([
-      for account in var.data_lake_account_access : [
+      for account in var.data_lake_account_access :
+      # Only include the Glue database resources if they are part of the same account environment
+      each.key == "all" || endswith(each.key, account.env_name) ? [
         aws_athena_data_catalog.data_lake[account.env_name].arn,
         "arn:aws:glue:${var.region}:${account.account_id}:catalog",
         "arn:aws:glue:${var.region}:${account.account_id}:database/${each.key == "all" ? "*" : each.key}",
         "arn:aws:glue:${var.region}:${account.account_id}:table/${each.key == "all" ? "*" : each.key}/*"
-      ]
+      ] : []
     ])
   }
 }

--- a/terragrunt/aws/variables.tf
+++ b/terragrunt/aws/variables.tf
@@ -4,6 +4,14 @@ variable "cloudwatch_alert_slack_webhook" {
   sensitive   = true
 }
 
+variable "data_lake_account_access" {
+  description = "List of data lake accounts that Superset has access to."
+  type = list(object({
+    env_name   = string
+    account_id = string
+  }))
+}
+
 variable "glue_databases" {
   description = "List of Glue databases to grant access to."
   type        = list(string)

--- a/terragrunt/env/prod/terragrunt.hcl
+++ b/terragrunt/env/prod/terragrunt.hcl
@@ -7,11 +7,19 @@ include {
 }
 
 inputs = {
+  data_lake_account_access = [
+    {
+      env_name   = "production"
+      account_id = "739275439843"
+    }
+  ]
+
   glue_databases = [
     "operations_aws_production",
     "platform_gc_forms_production",
     "platform_support_production",
   ]
+
   superset_database_instance_class  = "db.serverless"
   superset_database_instances_count = 1
   superset_database_min_capacity    = 1

--- a/terragrunt/env/staging/terragrunt.hcl
+++ b/terragrunt/env/staging/terragrunt.hcl
@@ -7,6 +7,17 @@ include {
 }
 
 inputs = {
+  data_lake_account_access = [
+    {
+      env_name   = "production"
+      account_id = "739275439843"
+    },
+    {
+      env_name   = "staging"
+      account_id = "454671348950"
+    }
+  ]
+
   glue_databases = [
     "platform_gc_forms_production",
     "platform_gc_forms_staging",
@@ -17,6 +28,7 @@ inputs = {
     "operations_aws_production",
     "bes_crm_salesforce_production",
   ]
+
   superset_database_instance_class  = "db.serverless"
   superset_database_instances_count = 1
   superset_database_min_capacity    = 1


### PR DESCRIPTION
# Summary
Update the Superset IAM roles used to access datasets in the Prod and Staging Data Lake accounts.  This change allows fine grained control over the Data Lake accounts that are available to Superset Prod and Staging.

With this configuration, the following permissions will be granted:
1. `Superset Staging`: access to both Prod/Staging Data Lake accounts.
2. `Superset Prod`: access to only Prod Data Lake account.

The reason Staging is allowed access to both Data Lake accounts is so that ad-hoc Prod dataset testing can be performed.