### PR TITLE
fix: revert the description change for the data catalog

### DIFF
--- a/terragrunt/aws/athena.tf
+++ b/terragrunt/aws/athena.tf
@@ -40,7 +40,7 @@ resource "aws_athena_data_catalog" "data_lake" {
   }
 
   name        = "data-lake-${each.key}"
-  description = "Data catalog for access to the CDS Data Lake ${each.key} environment"
+  description = "Data catalog for access to the CDS data lake"
   type        = "GLUE"
 
   parameters = {


### PR DESCRIPTION
# Summary
Updating the existing Athena data catalog's description is not supported through the API so I'm reverting the description change.