### PR TITLE
fix: route failed workflow notifications to correct channel

### DIFF
--- a/.github/workflows/workflow-failure.yml
+++ b/.github/workflows/workflow-failure.yml
@@ -18,7 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.conclusion == 'failure'
     steps:
+      - name: Determine target ops channel
+        run: |
+          WORKFLOW_NAME_LOWER="$(echo ${{ github.event.workflow_run.name }} | tr '[:upper:]' '[:lower:]')"
+          if [[ "$WORKFLOW_NAME_LOWER" == *"staging"* ]]; then
+            echo "SLACK_WEBHOOK_URL=${{ secrets.STAGING_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}" >> $GITHUB_ENV
+          else
+            echo "SLACK_WEBHOOK_URL=${{ secrets.PROD_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}" >> $GITHUB_ENV
+          fi
+
       - name: Notify Slack
         run: |
           json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Superset workflow failed: <${{ github.event.workflow_run.html_url }}|${{ github.event.workflow.name }}>"}}]}'
-          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.PROD_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
+          curl -X POST -H 'Content-type: application/json' --data "$json" ${{ env.SLACK_WEBHOOK_URL }}

--- a/terragrunt/aws/athena.tf
+++ b/terragrunt/aws/athena.tf
@@ -47,10 +47,3 @@ resource "aws_athena_data_catalog" "data_lake" {
     "catalog-id" = each.value
   }
 }
-
-# Migrate the data lake catalog resource to its new location in the TF state.
-# This can be removed once the change has been applied in prod.
-moved {
-  from = aws_athena_data_catalog.data_lake
-  to   = aws_athena_data_catalog.data_lake["production"]
-}


### PR DESCRIPTION
# Summary
Update the workflow failure notifier to sent to the appropriate Staging or Production ops channel, depending on the failed workflow's name.

Also removes the Athena `moved` block as the Terraform state migration has been completed.