### PR TITLE
fix: race condition to retrieve commit SHA

### DIFF
--- a/.github/workflows/docker-deploy-prod.yml
+++ b/.github/workflows/docker-deploy-prod.yml
@@ -10,7 +10,7 @@ env:
   AWS_REGION: ca-central-1
   ECS_CLUSTER: superset
   REGISTRY: ${{ vars.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/superset
-  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_SHA: ${{ github.event.workflow_run.head_branch }}
 
 permissions:
   id-token: write

--- a/.github/workflows/docker-deploy-staging.yml
+++ b/.github/workflows/docker-deploy-staging.yml
@@ -10,7 +10,7 @@ env:
   AWS_REGION: ca-central-1
   ECS_CLUSTER: superset
   REGISTRY: ${{ vars.STAGING_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/superset
-  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_SHA: ${{ github.event.workflow_run.head_sha }}
 
 permissions:
   id-token: write


### PR DESCRIPTION
# Summary
Update the Docker deploy workflows so they use the correct reference to the `main` branch commit that triggered their invocation.