### PR TITLE
feat: switch to Valkey caching engine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ x-superset-build:
     dockerfile: Dockerfile
 x-superset-depends-on: &superset-depends-on
   - db
-  - redis
+  - valkey
 x-superset-env: 
   &superset-env
   - path: docker/.env.local
@@ -15,12 +15,12 @@ x-superset-volumes:
   - superset_home:/app/superset_home
 
 services:
-  redis:
-    image: redis:7
+  valkey:
+    image: valkey/valkey:7
     container_name: superset_cache
     restart: unless-stopped
     volumes:
-      - redis:/data
+      - valkey:/data
 
   db:
     env_file: *superset-env
@@ -86,5 +86,5 @@ volumes:
     external: false
   db_home:
     external: false
-  redis:
+  valkey:
     external: false

--- a/docker/.env.local
+++ b/docker/.env.local
@@ -9,7 +9,7 @@ POSTGRES_DB=superset
 POSTGRES_USER=superset
 POSTGRES_PASSWORD=superset
 
-REDIS_HOST=redis
+REDIS_HOST=valkey
 REDIS_PORT=6379
 
 SUPERSET_ENV=development

--- a/terragrunt/aws/redis.tf
+++ b/terragrunt/aws/redis.tf
@@ -26,7 +26,7 @@ resource "aws_elasticache_cluster" "superset_cache" {
   node_type            = var.env == "prod" ? "cache.t2.small" : "cache.t2.micro"
   num_cache_nodes      = 1
   parameter_group_name = "default.valkey7"
-  engine_version       = "7"
+  engine_version       = "7.2"
   port                 = 6379
   subnet_group_name    = aws_elasticache_subnet_group.superset_cache.name
 

--- a/terragrunt/aws/redis.tf
+++ b/terragrunt/aws/redis.tf
@@ -19,3 +19,25 @@ resource "aws_elasticache_subnet_group" "superset" {
   name       = join("-", [local.prefix, "redis-subnet-grp"])
   subnet_ids = module.vpc.private_subnet_ids
 }
+
+resource "aws_elasticache_cluster" "superset_cache" {
+  cluster_id           = "superset-cache-${var.env}"
+  engine               = "valkey"
+  node_type            = var.env == "prod" ? "cache.t2.small" : "cache.t2.micro"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.valkey7"
+  engine_version       = "7"
+  port                 = 6379
+  subnet_group_name    = aws_elasticache_subnet_group.superset_cache.name
+
+  security_group_ids = [
+    aws_security_group.superset_redis.id,
+  ]
+
+  tags = local.common_tags
+}
+
+resource "aws_elasticache_subnet_group" "superset_cache" {
+  name       = "superset-cache-${var.env}"
+  subnet_ids = module.vpc.private_subnet_ids
+}


### PR DESCRIPTION
# Summary
Add a Valkey memcache that we'll use to cache Superset charts and dashboards.  The reason for this change is Valkey is ~33% cheaper than Redis and acts as drop-in replacement.

This change also slightly increases the cache size in Production as we have intermittently seen out-of-memory errors when trying to cache results.

The path for applying this change will be as follows:

1. Create the new cluster.
1. Switch Superset over to new cluster.
1. Delete existing Redis cluster.

# Related
- https://github.com/cds-snc/platform-core-services/issues/657