### PR TITLE
fix: creation of the Valkey memcache cluster

### DIFF
--- a/terragrunt/aws/cache.tf
+++ b/terragrunt/aws/cache.tf
@@ -20,16 +20,19 @@ resource "aws_elasticache_subnet_group" "superset" {
   subnet_ids = module.vpc.private_subnet_ids
 }
 
-resource "aws_elasticache_cluster" "superset_cache" {
-  cluster_id           = "superset-cache-${var.env}"
-  engine               = "valkey"
-  node_type            = var.env == "prod" ? "cache.t2.small" : "cache.t2.micro"
-  num_cache_nodes      = 1
-  parameter_group_name = "default.valkey7"
-  engine_version       = "7.2"
-  port                 = 6379
-  subnet_group_name    = aws_elasticache_subnet_group.superset_cache.name
 
+resource "aws_elasticache_replication_group" "superset_cache" {
+  replication_group_id = "superset-cache-${var.env}"
+  description          = "Valkey cache for Superset in ${var.env}"
+
+  engine               = "valkey"
+  engine_version       = "7.2"
+  parameter_group_name = "default.valkey7"
+  node_type            = var.env == "prod" ? "cache.t2.small" : "cache.t2.micro"
+  num_cache_clusters   = 1
+  port                 = 6379
+
+  subnet_group_name = aws_elasticache_subnet_group.superset_cache.name
   security_group_ids = [
     aws_security_group.superset_redis.id,
   ]


### PR DESCRIPTION
# Summary
The AWS replication group API endpoint is needed for creation of a Valkey memcache cluster.

# Related
- #423 