### PR TITLE
feat: switch to the fully operational Valkey cluster

### DIFF
--- a/terragrunt/aws/ecs.tf
+++ b/terragrunt/aws/ecs.tf
@@ -10,7 +10,7 @@ locals {
     },
     {
       "name"  = "REDIS_HOST"
-      "value" = split(".", aws_elasticache_replication_group.superset_cache.primary_endpoint_address)[0]
+      "value" = split(":", aws_elasticache_replication_group.superset_cache.primary_endpoint_address)[0]
     },
     {
       "name"  = "REDIS_PORT"

--- a/terragrunt/aws/ecs.tf
+++ b/terragrunt/aws/ecs.tf
@@ -10,11 +10,11 @@ locals {
     },
     {
       "name"  = "REDIS_HOST"
-      "value" = aws_elasticache_cluster.superset.cache_nodes[0]["address"]
+      "value" = split(".", aws_elasticache_replication_group.superset_cache.primary_endpoint_address)[0]
     },
     {
       "name"  = "REDIS_PORT"
-      "value" = tostring(aws_elasticache_cluster.superset.port)
+      "value" = tostring(aws_elasticache_replication_group.superset_cache.port)
     },
     {
       "name"  = "THUMBNAIL_SELENIUM_USER"


### PR DESCRIPTION
# Summary
Now that the new memcache cluster is up and running, switch over the ECS tasks to use it.  Once this is complete, a final PR will be created to remove the old Redis cluster.
