### PR TITLE
chore: remove the old Redis cache

### DIFF
--- a/terragrunt/aws/cache.tf
+++ b/terragrunt/aws/cache.tf
@@ -1,26 +1,3 @@
-resource "aws_elasticache_cluster" "superset" {
-  cluster_id           = join("-", [local.prefix, "redis"])
-  engine               = "redis"
-  node_type            = "cache.t2.micro"
-  num_cache_nodes      = 1
-  parameter_group_name = "default.redis7"
-  engine_version       = "7.1"
-  port                 = 6379
-  subnet_group_name    = aws_elasticache_subnet_group.superset.name
-
-  security_group_ids = [
-    aws_security_group.superset_redis.id,
-  ]
-
-  tags = local.common_tags
-}
-
-resource "aws_elasticache_subnet_group" "superset" {
-  name       = join("-", [local.prefix, "redis-subnet-grp"])
-  subnet_ids = module.vpc.private_subnet_ids
-}
-
-
 resource "aws_elasticache_replication_group" "superset_cache" {
   replication_group_id = "superset-cache-${var.env}"
   description          = "Valkey cache for Superset in ${var.env}"


### PR DESCRIPTION
# Summary
Remove the Redis cache now that we have fully switched over to the Valkey cache.