### PR TITLE
fix: remove port 80 load balancer listener

### DIFF
--- a/terragrunt/aws/load_balancer.tf
+++ b/terragrunt/aws/load_balancer.tf
@@ -74,21 +74,3 @@ resource "aws_lb_listener" "superset" {
 
   tags = local.common_tags
 }
-
-resource "aws_lb_listener" "superset_http_redirect" {
-  load_balancer_arn = aws_lb.superset.arn
-  port              = "80"
-  protocol          = "HTTP"
-
-  default_action {
-    type = "redirect"
-
-    redirect {
-      port        = "443"
-      protocol    = "HTTPS"
-      status_code = "HTTP_301"
-    }
-  }
-
-  tags = local.common_tags
-}

--- a/terragrunt/aws/vpc.tf
+++ b/terragrunt/aws/vpc.tf
@@ -68,16 +68,6 @@ resource "aws_security_group" "superset_lb" {
   tags        = local.common_tags
 }
 
-resource "aws_security_group_rule" "superset_lb_ingress_internet_http" {
-  description       = "Ingress from internet to load balancer (HTTP)"
-  type              = "ingress"
-  from_port         = 80
-  to_port           = 80
-  protocol          = "tcp"
-  security_group_id = aws_security_group.superset_lb.id
-  cidr_blocks       = ["0.0.0.0/0"]
-}
-
 resource "aws_security_group_rule" "superset_lb_ingress_internet_https" {
   description       = "Ingress from internet to load balancer (HTTPS)"
   type              = "ingress"


### PR DESCRIPTION
# Summary
Remove the port 80 LB listener.  This was present to upgrade insecure requests to port 443, but modern browsers are doing this already and it is leading to false-positives in our security scanning.

# Related
- https://github.com/cds-snc/platform-core-services/issues/709
- https://github.com/cds-snc/platform-core-services/issues/752