### PR TITLE
fix: drop support for TLS 1.2 connections

### DIFF
--- a/terragrunt/aws/load_balancer.tf
+++ b/terragrunt/aws/load_balancer.tf
@@ -59,7 +59,7 @@ resource "aws_lb_listener" "superset" {
   load_balancer_arn = aws_lb.superset.arn
   port              = "443"
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-FIPS-2023-04"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-3-FIPS-2023-04"
   certificate_arn   = aws_acm_certificate.superset.arn
 
   default_action {


### PR DESCRIPTION
# Summary 
Update the load balancer listener's SSL policy to only support TLS 1.3 connections.  This is another finding that has come out of the OSCAL validation work.

# Related
- https://github.com/cds-snc/platform-core-services/issues/709
- https://github.com/cds-snc/platform-core-services/issues/752