### PR TITLE
chore: lower min capacity scaling of database

### DIFF
--- a/terragrunt/env/prod/terragrunt.hcl
+++ b/terragrunt/env/prod/terragrunt.hcl
@@ -22,6 +22,6 @@ inputs = {
 
   superset_database_instance_class  = "db.serverless"
   superset_database_instances_count = 1
-  superset_database_min_capacity    = 1
+  superset_database_min_capacity    = 0.5
   superset_database_max_capacity    = 4
 }

--- a/terragrunt/env/staging/terragrunt.hcl
+++ b/terragrunt/env/staging/terragrunt.hcl
@@ -31,6 +31,6 @@ inputs = {
 
   superset_database_instance_class  = "db.serverless"
   superset_database_instances_count = 1
-  superset_database_min_capacity    = 1
+  superset_database_min_capacity    = 0
   superset_database_max_capacity    = 4
 }


### PR DESCRIPTION
# Summary
Update the Aurora Serverless min capacity for the database to save money during off-peak use.

ℹ️  Note that in Staging this won't result in a full pause of the database since the ECS service and RDS proxy maintain persistent connections.