### PR TITLE
fix: update CODEOWNERS for our team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# Users that are allowed to approve a release PR
-.release-please-manifest.json @cds-snc/platform-core-services
+# Users that are allowed to approve PRs
+* @cds-snc/platform-core-services


### PR DESCRIPTION
# Summary
Update the CODEOWNERS rules so that only the Platform Core Services team can approve PRs.

# Related
- https://github.com/cds-snc/platform-core-services/issues/757