### PR TITLE
feat: add Slack notification for Security PRs

### DIFF
--- a/.github/workflows/dependency-security-update.yml
+++ b/.github/workflows/dependency-security-update.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   dependency-security-update:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.title, '[security]')
+    if: contains(github.event.pull_request.title, '[security]') && github.actor == 'renovate[bot]'
     steps:
       - name: Send Slack notification
         run: |


### PR DESCRIPTION
# Summary
Add a workflow that posts to Slack when a new dependency security PR is opened by Renovate.

# Related
- https://github.com/cds-snc/platform-core-services/issues/764