### PR TITLE
feat: enable AWS Shield Advanced

### DIFF
--- a/terragrunt/aws/route53.tf
+++ b/terragrunt/aws/route53.tf
@@ -14,8 +14,3 @@ resource "aws_route53_record" "superset_A" {
     evaluate_target_health = false
   }
 }
-
-moved {
-  from = aws_route53_zone.superset_cds_snc[0]
-  to   = aws_route53_zone.superset
-}

--- a/terragrunt/aws/waf.tf
+++ b/terragrunt/aws/waf.tf
@@ -495,3 +495,18 @@ module "waf_ip_blocklist" {
 
   billing_tag_value = var.billing_code
 }
+
+#
+# AWS Shield Advanced
+#
+resource "aws_shield_protection" "superset_alb" {
+  name         = "superset-alb"
+  resource_arn = aws_lb.superset.arn
+  tags         = local.common_tags
+}
+
+resource "aws_shield_protection" "superset_route53" {
+  name         = "superset-route53"
+  resource_arn = aws_route53_zone.superset.zone_id
+  tags         = local.common_tags
+}

--- a/terragrunt/aws/waf.tf
+++ b/terragrunt/aws/waf.tf
@@ -507,6 +507,6 @@ resource "aws_shield_protection" "superset_alb" {
 
 resource "aws_shield_protection" "superset_route53" {
   name         = "superset-route53"
-  resource_arn = aws_route53_zone.superset.zone_id
+  resource_arn = aws_route53_zone.superset.arn
   tags         = local.common_tags
 }


### PR DESCRIPTION
# Summary
Enable AWS Shield Advanced auto mitigations for the load balancer and hosted zone.

Also removes a Terraform state migration that has been completed.

# Related
- https://github.com/cds-snc/platform-core-services/issues/761