### PR TITLE
fix: add automatic block rule for Shield Advanced

### DIFF
--- a/terragrunt/aws/waf.tf
+++ b/terragrunt/aws/waf.tf
@@ -510,3 +510,8 @@ resource "aws_shield_protection" "superset_route53" {
   resource_arn = aws_route53_zone.superset.arn
   tags         = local.common_tags
 }
+
+resource "aws_shield_application_layer_automatic_response" "superset_alb" {
+  resource_arn = aws_lb.superset.arn
+  action       = "BLOCK"
+}


### PR DESCRIPTION
# Summary
Update the Shield Advanced configuration to add automatic BLOCK rules when malicious traffic is detected.

## ℹ️  Note
This was applied locally to test.

# Related
- https://github.com/cds-snc/platform-core-services/issues/761