### PR TITLE
fix: pin GitHub actions to commit SHAs

### DIFF
--- a/.github/workflows/backstage-catalog-helper.yml
+++ b/.github/workflows/backstage-catalog-helper.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Backstage Catalog Info Helper
-        uses: cds-snc/backstage-catalog-info-helper-action@e36696cef34ed39c43a6e4a3873821bb2bad7eef # v0.3.1
+        uses: cds-snc/backstage-catalog-info-helper-action@cc75afc29a0ade6c41400132ff9e1222f8916ba6
         with:
           github_app_id: ${{ secrets.SRE_BOT_RW_APP_ID }}
           github_app_private_key: ${{ secrets.SRE_BOT_RW_PRIVATE_KEY }}

--- a/.github/workflows/backstage-catalog-helper.yml
+++ b/.github/workflows/backstage-catalog-helper.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run Backstage Catalog Info Helper
-        uses: cds-snc/backstage-catalog-info-helper-action@v0.3.1
+        uses: cds-snc/backstage-catalog-info-helper-action@e36696cef34ed39c43a6e4a3873821bb2bad7eef # v0.3.1
         with:
           github_app_id: ${{ secrets.SRE_BOT_RW_APP_ID }}
           github_app_private_key: ${{ secrets.SRE_BOT_RW_PRIVATE_KEY }}

--- a/.github/workflows/docker-apply-prod.yml
+++ b/.github/workflows/docker-apply-prod.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Audit DNS requests
-      uses: cds-snc/dns-proxy-action@main
+      uses: cds-snc/dns-proxy-action@2aee21aebfddefac5839497648a36a9f84342d8b
       env:
         DNS_PROXY_FORWARDTOSENTINEL: "true"
         DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}

--- a/.github/workflows/docker-apply-staging.yml
+++ b/.github/workflows/docker-apply-staging.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Audit DNS requests
-      uses: cds-snc/dns-proxy-action@main
+      uses: cds-snc/dns-proxy-action@2aee21aebfddefac5839497648a36a9f84342d8b
       env:
         DNS_PROXY_FORWARDTOSENTINEL: "true"
         DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}

--- a/.github/workflows/docker-deploy-prod.yml
+++ b/.github/workflows/docker-deploy-prod.yml
@@ -27,7 +27,7 @@ jobs:
           - celery-beat
     steps:
     - name: Audit DNS requests
-      uses: cds-snc/dns-proxy-action@main
+      uses: cds-snc/dns-proxy-action@2aee21aebfddefac5839497648a36a9f84342d8b
       env:
         DNS_PROXY_FORWARDTOSENTINEL: "true"
         DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}

--- a/.github/workflows/docker-deploy-staging.yml
+++ b/.github/workflows/docker-deploy-staging.yml
@@ -27,7 +27,7 @@ jobs:
           - celery-beat
     steps:
     - name: Audit DNS requests
-      uses: cds-snc/dns-proxy-action@main
+      uses: cds-snc/dns-proxy-action@2aee21aebfddefac5839497648a36a9f84342d8b
       env:
         DNS_PROXY_FORWARDTOSENTINEL: "true"
         DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}

--- a/.github/workflows/docker-pr.yml
+++ b/.github/workflows/docker-pr.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
       - name: Audit DNS requests
-        uses: cds-snc/dns-proxy-action@main
+        uses: cds-snc/dns-proxy-action@2aee21aebfddefac5839497648a36a9f84342d8b
         env:
           DNS_PROXY_FORWARDTOSENTINEL: "true"
           DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Audit DNS requests
-        uses: cds-snc/dns-proxy-action@main
+        uses: cds-snc/dns-proxy-action@2aee21aebfddefac5839497648a36a9f84342d8b
         env:
           DNS_PROXY_FORWARDTOSENTINEL: "true"
           DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
@@ -67,7 +67,7 @@ jobs:
     steps: 
 
       - name: Audit DNS requests
-        uses: cds-snc/dns-proxy-action@main
+        uses: cds-snc/dns-proxy-action@2aee21aebfddefac5839497648a36a9f84342d8b
         env:
           DNS_PROXY_FORWARDTOSENTINEL: "true"
           DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}

--- a/.github/workflows/export_github_data.yml
+++ b/.github/workflows/export_github_data.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Audit DNS requests
-        uses: cds-snc/dns-proxy-action@main
+        uses: cds-snc/dns-proxy-action@2aee21aebfddefac5839497648a36a9f84342d8b
         env:
           DNS_PROXY_FORWARDTOSENTINEL: "true"
           DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
           DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Export Data
-        uses: cds-snc/github-repository-metadata-exporter@main
+        uses: cds-snc/github-repository-metadata-exporter@7f8f3eccaf3e15675fc70611e913ec1458510540
         with:
           github-app-id: ${{ secrets.SRE_BOT_RO_APP_ID }}
           github-app-installation-id: ${{ secrets.SRE_BOT_RO_INSTALLATION_ID }}

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Sync repository labels
     steps:
-      - uses: cds-snc/labels@v1
+      - uses: cds-snc/labels@8d95ffe4ae0bd4f148da0b5f082f1e5aa6cb72bf # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -39,7 +39,7 @@ jobs:
           jq -c '. + {"metadata_owner": "'$OWNER'", "metadata_repo": "'$REPO'", "metadata_query": "ossf"}' ossf-results.json > ossf-results-modified.json
 
       - name: "Post results to Sentinel"
-        uses: cds-snc/sentinel-forward-data-action@main
+        uses: cds-snc/sentinel-forward-data-action@01db4a9203054ecdb60ff368c3cdfca71d62e85f
         with:
           file_name: ossf-results-modified.json
           log_type: GitHubMetadata_OSSF_Scorecard

--- a/.github/workflows/tf-apply-prod.yml
+++ b/.github/workflows/tf-apply-prod.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
 
       - name: Audit DNS requests
-        uses: cds-snc/dns-proxy-action@main
+        uses: cds-snc/dns-proxy-action@2aee21aebfddefac5839497648a36a9f84342d8b
         env:
           DNS_PROXY_FORWARDTOSENTINEL: "true"
           DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: setup terraform tools
-        uses: cds-snc/terraform-tools-setup@v1
+        uses: cds-snc/terraform-tools-setup@9028ea5f79f3ec78d2c68a4893c10403bfe84838 # v1
 
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1

--- a/.github/workflows/tf-apply-staging.yml
+++ b/.github/workflows/tf-apply-staging.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
 
       - name: Audit DNS requests
-        uses: cds-snc/dns-proxy-action@main
+        uses: cds-snc/dns-proxy-action@2aee21aebfddefac5839497648a36a9f84342d8b
         env:
           DNS_PROXY_FORWARDTOSENTINEL: "true"
           DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: setup terraform tools
-        uses: cds-snc/terraform-tools-setup@v1
+        uses: cds-snc/terraform-tools-setup@9028ea5f79f3ec78d2c68a4893c10403bfe84838 # v1
 
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1

--- a/.github/workflows/tf-plan-prod.yml
+++ b/.github/workflows/tf-plan-prod.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Audit DNS requests
-        uses: cds-snc/dns-proxy-action@main
+        uses: cds-snc/dns-proxy-action@2aee21aebfddefac5839497648a36a9f84342d8b
         env:
           DNS_PROXY_FORWARDTOSENTINEL: "true"
           DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: setup terraform tools
-        uses: cds-snc/terraform-tools-setup@v1
+        uses: cds-snc/terraform-tools-setup@9028ea5f79f3ec78d2c68a4893c10403bfe84838 # v1
 
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1

--- a/.github/workflows/tf-plan-staging.yml
+++ b/.github/workflows/tf-plan-staging.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Audit DNS requests
-        uses: cds-snc/dns-proxy-action@main
+        uses: cds-snc/dns-proxy-action@2aee21aebfddefac5839497648a36a9f84342d8b
         env:
           DNS_PROXY_FORWARDTOSENTINEL: "true"
           DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: setup terraform tools
-        uses: cds-snc/terraform-tools-setup@v1
+        uses: cds-snc/terraform-tools-setup@9028ea5f79f3ec78d2c68a4893c10403bfe84838 # v1
 
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1


### PR DESCRIPTION
# Summary
Update the GitHub action version pinning so that immutable commit SHAs are used.  This will make it more difficult for malicious code to be injected into our workflows.

# Related
- https://github.com/cds-snc/platform-core-services/issues/758