### PR TITLE
fix: privileged role grant regular expression

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -256,7 +256,7 @@ resource "aws_cloudwatch_metric_alarm" "superset_ecs_errors" {
 #
 resource "aws_cloudwatch_log_metric_filter" "superset_privileged_role_grant" {
   name           = "privileged-role-grant"
-  pattern        = "[(w1=\"*INSERT INTO ab_user_role.*[${join("|", var.superset_privileged_role_ids)}]\\) RETURNING*\")]"
+  pattern        = "%.*INSERT INTO ab_user_role.*[${join("|", var.superset_privileged_role_ids)}]. RETURNING ab_user_role.id...not logged.$%"
   log_group_name = "/aws/rds/cluster/${module.superset_db.rds_cluster_id}/postgresql"
 
   metric_transformation {


### PR DESCRIPTION
# Summary
Update the CloudWatch metric filter regex used by the privileged role grant alarm.

# Related
- https://github.com/cds-snc/platform-core-services/issues/759