### PR TITLE
fix: switch to Sentinel forwarder to capture role grants

### DIFF
--- a/.github/workflows/tf-apply-prod.yml
+++ b/.github/workflows/tf-apply-prod.yml
@@ -12,9 +12,10 @@ env:
   TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.PROD_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
   TF_VAR_google_oauth_client_id: ${{ secrets.PROD_GOOGLE_OAUTH_CLIENT_ID }}
   TF_VAR_google_oauth_client_secret: ${{ secrets.PROD_GOOGLE_OAUTH_CLIENT_SECRET }}  
+  TF_VAR_sentinel_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+  TF_VAR_sentinel_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
   TF_VAR_superset_database_username: ${{ secrets.PROD_SUPERSET_DATABASE_USERNAME }}
   TF_VAR_superset_database_password: ${{ secrets.PROD_SUPERSET_DATABASE_PASSWORD }}
-  TF_VAR_superset_privileged_role_ids: ${{ secrets.PROD_SUPERSET_PRIVILEGED_ROLE_IDS }}
   TF_VAR_superset_secret_key: ${{ secrets.PROD_SUPERSET_SECRET_KEY }}
   TF_VAR_upptime_status_header: ${{ secrets.PROD_UPPTIME_STATUS_HEADER }}
   

--- a/.github/workflows/tf-apply-staging.yml
+++ b/.github/workflows/tf-apply-staging.yml
@@ -17,10 +17,11 @@ env:
   TERRAGRUNT_VERSION: 0.58.3
   TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.STAGING_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
   TF_VAR_google_oauth_client_id: ${{ secrets.STAGING_GOOGLE_OAUTH_CLIENT_ID }}
-  TF_VAR_google_oauth_client_secret: ${{ secrets.STAGING_GOOGLE_OAUTH_CLIENT_SECRET }}  
+  TF_VAR_google_oauth_client_secret: ${{ secrets.STAGING_GOOGLE_OAUTH_CLIENT_SECRET }}
+  TF_VAR_sentinel_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+  TF_VAR_sentinel_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
   TF_VAR_superset_database_username: ${{ secrets.STAGING_SUPERSET_DATABASE_USERNAME }}
   TF_VAR_superset_database_password: ${{ secrets.STAGING_SUPERSET_DATABASE_PASSWORD }}
-  TF_VAR_superset_privileged_role_ids: ${{ secrets.STAGING_SUPERSET_PRIVILEGED_ROLE_IDS }}
   TF_VAR_superset_secret_key: ${{ secrets.STAGING_SUPERSET_SECRET_KEY }}
   TF_VAR_upptime_status_header: ${{ secrets.STAGING_UPPTIME_STATUS_HEADER }}
   

--- a/.github/workflows/tf-plan-prod.yml
+++ b/.github/workflows/tf-plan-prod.yml
@@ -14,10 +14,11 @@ env:
   TF_SUMMARIZE_VERSION: 0.3.5
   TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.PROD_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
   TF_VAR_google_oauth_client_id: ${{ secrets.PROD_GOOGLE_OAUTH_CLIENT_ID }}
-  TF_VAR_google_oauth_client_secret: ${{ secrets.PROD_GOOGLE_OAUTH_CLIENT_SECRET }}  
+  TF_VAR_google_oauth_client_secret: ${{ secrets.PROD_GOOGLE_OAUTH_CLIENT_SECRET }}
+  TF_VAR_sentinel_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+  TF_VAR_sentinel_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
   TF_VAR_superset_database_username: ${{ secrets.PROD_SUPERSET_DATABASE_USERNAME }}
   TF_VAR_superset_database_password: ${{ secrets.PROD_SUPERSET_DATABASE_PASSWORD }}
-  TF_VAR_superset_privileged_role_ids: ${{ secrets.PROD_SUPERSET_PRIVILEGED_ROLE_IDS }}
   TF_VAR_superset_secret_key: ${{ secrets.PROD_SUPERSET_SECRET_KEY }}
   TF_VAR_upptime_status_header: ${{ secrets.PROD_UPPTIME_STATUS_HEADER }}
 

--- a/.github/workflows/tf-plan-staging.yml
+++ b/.github/workflows/tf-plan-staging.yml
@@ -16,9 +16,10 @@ env:
   TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.STAGING_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
   TF_VAR_google_oauth_client_id: ${{ secrets.STAGING_GOOGLE_OAUTH_CLIENT_ID }}
   TF_VAR_google_oauth_client_secret: ${{ secrets.STAGING_GOOGLE_OAUTH_CLIENT_SECRET }}
+  TF_VAR_sentinel_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+  TF_VAR_sentinel_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
   TF_VAR_superset_database_username: ${{ secrets.STAGING_SUPERSET_DATABASE_USERNAME }}
   TF_VAR_superset_database_password: ${{ secrets.STAGING_SUPERSET_DATABASE_PASSWORD }}
-  TF_VAR_superset_privileged_role_ids: ${{ secrets.STAGING_SUPERSET_PRIVILEGED_ROLE_IDS }}
   TF_VAR_superset_secret_key: ${{ secrets.STAGING_SUPERSET_SECRET_KEY }}
   TF_VAR_upptime_status_header: ${{ secrets.STAGING_UPPTIME_STATUS_HEADER }}
 

--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -283,6 +283,8 @@ module "sentinel_forwarder" {
   cloudwatch_log_arns = [
     "arn:aws:logs:${var.region}:${var.account_id}:log-group:${local.rds_cluster_postgresql_log_group_name}"
   ]
+
+  billing_tag_value = var.billing_code
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "superset_role_grant" {

--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -5,6 +5,8 @@ locals {
     module.celery_worker_ecs
   ])
 
+  rds_cluster_postgresql_log_group_name = "/aws/rds/cluster/${module.superset_db.rds_cluster_id}/postgresql"
+
   superset_error_filters = [
     "CRITICAL", "ERROR"
   ]
@@ -252,40 +254,6 @@ resource "aws_cloudwatch_metric_alarm" "superset_ecs_errors" {
 }
 
 #
-# Privileged role granted to user
-#
-resource "aws_cloudwatch_log_metric_filter" "superset_privileged_role_grant" {
-  name           = "privileged-role-grant"
-  pattern        = "%.*INSERT INTO ab_user_role.*[${join("|", var.superset_privileged_role_ids)}]. RETURNING ab_user_role.id...not logged.$%"
-  log_group_name = "/aws/rds/cluster/${module.superset_db.rds_cluster_id}/postgresql"
-
-  metric_transformation {
-    name          = "privileged-role-grant"
-    namespace     = "superset"
-    value         = "1"
-    default_value = "0"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "superset_privileged_role_grant" {
-  alarm_name          = "privileged-role-grant"
-  alarm_description   = "Privileged role was granted in Superset."
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = "1"
-  metric_name         = aws_cloudwatch_log_metric_filter.superset_privileged_role_grant.metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.superset_privileged_role_grant.metric_transformation[0].namespace
-  period              = "60"
-  statistic           = "Sum"
-  threshold           = "0"
-  treat_missing_data  = "notBreaching"
-
-  alarm_actions = [aws_sns_topic.cloudwatch_alert_warning.arn]
-  ok_actions    = [aws_sns_topic.cloudwatch_alert_ok.arn]
-
-  tags = local.common_tags
-}
-
-#
 # Log Insight queries
 #
 resource "aws_cloudwatch_query_definition" "superset_ecs_errors" {
@@ -301,15 +269,26 @@ resource "aws_cloudwatch_query_definition" "superset_ecs_errors" {
   QUERY
 }
 
-resource "aws_cloudwatch_query_definition" "superset_privileged_role_grant" {
-  name = "Superset - privileged role grant"
+#
+# Sentinel Forwarder
+#
+module "sentinel_forwarder" {
+  source = "github.com/cds-snc/terraform-modules//sentinel_forwarder?ref=v10.6.0"
 
-  log_group_names = ["/aws/rds/cluster/${module.superset_db.rds_cluster_id}/postgresql"]
+  function_name = "sentinel-forwarder"
+  layer_arn     = "arn:aws:lambda:ca-central-1:283582579564:layer:aws-sentinel-connector-layer:216"
+  customer_id   = var.sentinel_workspace_id
+  shared_key    = var.sentinel_workspace_key
 
-  query_string = <<-QUERY
-    fields @timestamp, @message, @logStream
-    | filter @message like /INSERT INTO ab_user_role.*[${join("|", var.superset_privileged_role_ids)}]\) RETURNING/
-    | sort @timestamp desc
-    | limit 100
-  QUERY
+  cloudwatch_log_arns = [
+    "arn:aws:logs:${var.region}:${var.account_id}:log-group:${local.rds_cluster_postgresql_log_group_name}"
+  ]
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "superset_role_grant" {
+  name            = "Superset role grant"
+  log_group_name  = local.rds_cluster_postgresql_log_group_name
+  filter_pattern  = "INSERT INTO ab_user_role"
+  destination_arn = module.sentinel_forwarder.lambda_arn
+  distribution    = "Random"
 }

--- a/terragrunt/aws/variables.tf
+++ b/terragrunt/aws/variables.tf
@@ -29,6 +29,18 @@ variable "google_oauth_client_secret" {
   sensitive   = true
 }
 
+variable "sentinel_workspace_id" {
+  description = "Workspace ID for Sentinel Forwarder."
+  type        = string
+  sensitive   = true
+}
+
+variable "sentinel_workspace_key" {
+  description = "Workspace key for Sentinel Forwarder."
+  type        = string
+  sensitive   = true
+}
+
 variable "superset_database_instances_count" {
   description = "The number of instances in the database cluster."
   type        = number
@@ -58,12 +70,6 @@ variable "superset_database_username" {
 variable "superset_database_password" {
   description = "The password to use for the database."
   type        = string
-  sensitive   = true
-}
-
-variable "superset_privileged_role_ids" {
-  description = "List of role IDs that have privileged access to data."
-  type        = list(number)
   sensitive   = true
 }
 


### PR DESCRIPTION
# Summary
Update to use a Sentinel alert to check if a privileged role has been granted.  This is needed because of the limitations of the CloudWatch metric filter regular expressions.

This PR is step one of the change to get the logs into Sentinel.  Once it's running, the new Sentinel alert will be created.