### PR TITLE
fix: WAF anti-DDoS manage rule config

### DIFF
--- a/terragrunt/aws/waf.tf
+++ b/terragrunt/aws/waf.tf
@@ -333,6 +333,9 @@ resource "aws_wafv2_web_acl" "superset" {
               challenge {
                 sensitivity     = "HIGH"
                 usage_of_action = "ENABLED"
+                exempt_uri_regular_expression {
+                  regex_string = "/api/|.(acc|avi|css|gif|jpe?g|js|pdf|png|tiff?|ttf|webm|webp|woff2?)$"
+                }
               }
             }
           }


### PR DESCRIPTION
# Summary
Update the managed anit-DDoS rule to include the list of URLs that should be excluded from challenge requests during an attack.

# :warning: Note
This was applied locally to test the config.