### PR TITLE
fix: remove dev dependencies from base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,12 @@
 FROM apache/superset:4.1.2@sha256:15e110b8533d3cb6a0d529512ea71252b0ac62e3f72b1f7a5000f1361822ac26
 USER root
 
+# Remove dev dependencies
+RUN apt-get update && \
+    apt-get purge linux-libc-dev libc6-dev libldap-dev libldap2-dev libssl-dev -y && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
 # Add required database driver packages
 # https://superset.apache.org/installation.html#database-dependencies
 COPY requirements.txt /app/requirements.txt


### PR DESCRIPTION
# Summary
Remove the `-dev` dependencies as they are not needed to run Superset and are full of vulnerabilities adding noise to our scan results.

# Related
- https://github.com/cds-snc/platform-core-services/issues/745