### PR TITLE
fix: upgrade to latest version of gunicorn

### DIFF
--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,4 +1,5 @@
 authlib==1.6.0
+gunicorn==23.0.0
 Flask-Session==0.8.0
 prophet==1.1.7
 psycopg2-binary==2.9.10


### PR DESCRIPTION
# Summary
Upgrade gunicorn to v23.0.0 to improve performance and receive latest fixes.
