### PR TITLE
fix: remove the dashboard cache warmup scheduled task

### DIFF
--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -80,15 +80,6 @@ class CeleryConfig(object):
             "schedule": crontab(minute=0, hour="*/12"),
             "kwargs": {"strategy_name": "dummy"},
         },
-        "cache-warmup-dashboard": {
-            "task": "cache-warmup",
-            "schedule": crontab(minute=15, hour="*/12"),
-            "kwargs": {
-                "strategy_name": "top_n_dashboards",
-                "top_n": 10,
-                "since": "7 days ago",
-            },
-        },
     }
 
 


### PR DESCRIPTION
# Summary
Remove the dashboard cache warmup task.  There is already a chart cache warmup that is doing the same thing, so all the dashboard charts should already be pre-cached.