### PR TITLE
fix: import database integration tests only for app config

### DIFF
--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -167,6 +167,7 @@ def app_mutator(app):
     # Run integration tests if needed
     if os.getenv("SUPERSET_APP") == "true":
         from superset.integration_tests import database
+
         database.test_access(app)
 
     # Workaround bug in Superset not updating the main menu translations


### PR DESCRIPTION
# Summary
Update the Superset config so that it only attempts to import the database integration tests in the context of the app.

This should prevent the missing module errors we've been getting in the database upgrade task.
