### PR TITLE
chore: suppress thumbnail retrieval error

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -15,6 +15,7 @@ locals {
     "COLUMN_NOT_FOUND",
     "contains non-numeric values",
     "DML_NOT_ALLOWED_ERROR",
+    "Error handling request /api/v1/*/thumbnail/",
     "Error on OAuth authorize",
     "Error warming up cache",
     "Failed to execute query",


### PR DESCRIPTION
# Summary
Update the alarms so that failed thumbnail requests do not trigger a CloudWatch alarm.  These failed requests are retried and non-user impacting.