### PR TITLE
fix: suppress thumbnail generate time out

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -29,6 +29,7 @@ locals {
     "Table does not exist",
     "TABLE_DOES_NOT_EXIST_ERROR",
     "TABLE_NOT_FOUND",
+    "Timed out requesting url http://superset.superset.ecs.local*",
     "TYPE_MISMATCH",
     "Unsupported format",
     "Unsupported table"


### PR DESCRIPTION
# Summary
Add another CloudWatch alarm filter so that these non-user impacting errors do not trigger an alarm.