### PR TITLE
fix: suppress thumbnail cache alarms

### DIFF
--- a/terragrunt/aws/alarms.tf
+++ b/terragrunt/aws/alarms.tf
@@ -29,7 +29,9 @@ locals {
     "Table does not exist",
     "TABLE_DOES_NOT_EXIST_ERROR",
     "TABLE_NOT_FOUND",
-    "Timed out requesting url http://superset.superset.ecs.local*",
+    "Task cache_dashboard_thumbnail",
+    "Timed out requesting url http://superset.superset.ecs.local",
+    "Timed out waiting for charts to load at url http://superset.superset.ecs.local",
     "TYPE_MISMATCH",
     "Unsupported format",
     "Unsupported table"


### PR DESCRIPTION
# Summary
Add a few more alarm suppressions for non-user impacting errors around generating dashboard and chart thumbnails.