### PR TITLE
feat: improve session authenticity protection

### DIFF
--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -164,6 +164,7 @@ EMAIL_REPORTS_SUBJECT_PREFIX = "[CDS Superset] "
 
 RATELIMIT_STORAGE_URI = REDIS_URL
 WTF_CSRF_ENABLED = True
+WTF_CSRF_TIME_LIMIT = int(timedelta(hours=12).total_seconds())
 WTF_CSRF_EXEMPT_LIST = [
     "superset.views.core.log",
     "superset.views.core.explore_json",

--- a/terragrunt/aws/load_balancer.tf
+++ b/terragrunt/aws/load_balancer.tf
@@ -42,7 +42,8 @@ resource "aws_lb_target_group" "superset" {
   }
 
   stickiness {
-    type = "lb_cookie"
+    type            = "lb_cookie"
+    cookie_duration = 43200 # 12 hours
   }
 
   tags = local.common_tags


### PR DESCRIPTION
# Summary
Strengthen the session authenticity protection by reducing the load balancer session affinity and CSRF token validity periods to 12 hours.

# Related
- https://github.com/cds-snc/superset-system-level-security-controls/issues/60