### PR TITLE
feat: set the Superset log format and level

### DIFF
--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -14,6 +14,10 @@ logger = logging.getLogger()
 
 logger.info("Setting up custom config for Superset")
 
+# Log config
+LOG_FORMAT = "%(asctime)s:%(levelname)s:%(name)s:%(message)s"
+LOG_LEVEL = logging.DEBUG if DEBUG else logging.INFO
+
 # Database
 DATABASE_USER = os.getenv("SUPERSET_DATABASE_USER")
 DATABASE_PASSWORD = os.getenv("SUPERSET_DATABASE_PASSWORD")

--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -16,7 +16,7 @@ logger.info("Setting up custom config for Superset")
 
 # Log config
 LOG_FORMAT = "%(asctime)s:%(levelname)s:%(name)s:%(message)s"
-LOG_LEVEL = logging.DEBUG if DEBUG else logging.INFO
+LOG_LEVEL = logging.INFO
 
 # Database
 DATABASE_USER = os.getenv("SUPERSET_DATABASE_USER")


### PR DESCRIPTION
# Summary
Set the default logging format and level.  This is the same default applied by Superset upstream but gives us flexibility in the future and simplifies SA&A evidence collection.