### PR TITLE
fix: increase CloudWatch log retention to 365 days

### DIFF
--- a/terragrunt/aws/database.tf
+++ b/terragrunt/aws/database.tf
@@ -20,7 +20,7 @@ module "superset_db" {
   # Enable audit logging to CloudWatch
   db_cluster_parameter_group_name          = aws_rds_cluster_parameter_group.superset_db.name
   enabled_cloudwatch_logs_exports          = ["postgresql"]
-  cloudwatch_log_exports_retention_in_days = 30
+  cloudwatch_log_exports_retention_in_days = 365
 
   serverless_min_capacity = var.superset_database_min_capacity
   serverless_max_capacity = var.superset_database_max_capacity

--- a/terragrunt/aws/ecs.tf
+++ b/terragrunt/aws/ecs.tf
@@ -136,6 +136,9 @@ module "superset_ecs" {
   service_discovery_enabled      = true
   service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.superset.id
 
+  # Logging
+  cloudwatch_log_group_retention_in_days = 365
+
   # Allow executing commands on the task
   enable_execute_command = false
 
@@ -181,6 +184,9 @@ module "celery_worker_ecs" {
   service_discovery_enabled      = true
   service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.superset.id
 
+  # Logging
+  cloudwatch_log_group_retention_in_days = 365
+
   billing_tag_value = var.billing_code
 }
 
@@ -219,6 +225,9 @@ module "celery_beat_ecs" {
   security_group_ids             = [aws_security_group.superset_ecs.id]
   service_discovery_enabled      = true
   service_discovery_namespace_id = aws_service_discovery_private_dns_namespace.superset.id
+
+  # Logging
+  cloudwatch_log_group_retention_in_days = 365
 
   billing_tag_value = var.billing_code
 }


### PR DESCRIPTION
# Summary
Update the log group retention period to 365 days to satisfy NIST control AU-12.