### PR TITLE
fix: upgrade VPC to add SSH/RDP NACL block

### DIFF
--- a/terragrunt/aws/vpc.tf
+++ b/terragrunt/aws/vpc.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 module "vpc" {
-  source = "github.com/cds-snc/terraform-modules//vpc?ref=v10.7.0"
+  source = "github.com/cds-snc/terraform-modules//vpc?ref=v10.7.1"
   name   = "superspace-${var.env}"
 
   enable_flow_log                  = true


### PR DESCRIPTION
# Summary
Upgrade to latest VPC module release that contains the fix for the missing NACL `deny` rules.
