### PR TITLE
fix: tighten workflow security

### DIFF
--- a/.github/workflows/docker-vulnerability-scan.yml
+++ b/.github/workflows/docker-vulnerability-scan.yml
@@ -5,16 +5,12 @@ on:
   schedule:
     - cron: "0 4 * * *"
 
-env:
-  REGISTRY: ${{ vars.STAGING_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/superset
-
 permissions:
-  id-token: write
   security-events: write
 
 jobs:
   docker-vulnerability-scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout
@@ -22,22 +18,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Configure AWS credentials using OIDC
-        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
-        with:
-          role-to-assume: arn:aws:iam::${{ vars.STAGING_AWS_ACCOUNT_ID }}:role/cds-superset-plan
-          role-session-name: ECRPull
-          aws-region: ca-central-1
-
-      - name: Login to ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@261fc3d4806db1fa66a15cc11113c456db8870a7 # v2.1.0
+      - name: Build Docker image
+        working-directory: ./
+        run: |
+          docker build \
+          --file ./docker/Dockerfile \
+          --tag cds-superset ./docker \
+          --platform linux/arm64
 
       - name: Docker vulnerability scan
-        uses: cds-snc/security-tools/.github/actions/docker-scan@837a88b6337d4842543184c8eac97a8adac8f302
+        uses: cds-snc/security-tools/.github/actions/docker-scan@837a88b6337d4842543184c8eac97a8adac8f302 # v4.0.3
         env:
           TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
         with:
-          docker_image: "${{ env.REGISTRY }}:latest"
+          docker_image: "cds-superset:latest"
           dockerfile_path: "./docker/Dockerfile"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tf-apply-prod.yml
+++ b/.github/workflows/tf-apply-prod.yml
@@ -13,8 +13,6 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.14.4
-  TERRAGRUNT_VERSION: 0.99.1
   TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.PROD_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
   TF_VAR_google_oauth_client_id: ${{ secrets.PROD_GOOGLE_OAUTH_CLIENT_ID }}
   TF_VAR_google_oauth_client_secret: ${{ secrets.PROD_GOOGLE_OAUTH_CLIENT_SECRET }}
@@ -73,8 +71,16 @@ jobs:
           ref: ${{ env.VERSION }}
           persist-credentials: false
 
-      - name: Setup terraform tools
-        uses: cds-snc/terraform-tools-setup@5a19984bcb888600ad646e0caf5c6f4d0a54c165 # v1.2.0
+      - name: Setup Terraform tools
+        uses: cds-snc/terraform-tools-setup@36df0d7572a15921998170395475093c183d720a # v1.3.0
+        env:
+          CONFTEST_VERSION: NONE
+          TERRAFORM_VERSION: 1.14.4
+          TERRAFORM_CHECKSUM: 4a24b18865d9419ba7882567cb7429dd1525b3e2029a9e38f612d476ba8c3dea
+          TERRAGRUNT_VERSION: 0.99.1
+          TERRAGRUNT_CHECKSUM: 7d0a7ad656cf175afdf7cb2b8a51721f4a36dbeef5fb3a37b22f1b59aaacee6d
+          TF_SUMMARIZE_VERSION: NONE
+          TRUFFLEHOG_VERSION: NONE
 
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/.github/workflows/tf-apply-staging.yml
+++ b/.github/workflows/tf-apply-staging.yml
@@ -17,8 +17,6 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.14.4
-  TERRAGRUNT_VERSION: 0.99.1
   TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.STAGING_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
   TF_VAR_google_oauth_client_id: ${{ secrets.STAGING_GOOGLE_OAUTH_CLIENT_ID }}
   TF_VAR_google_oauth_client_secret: ${{ secrets.STAGING_GOOGLE_OAUTH_CLIENT_SECRET }}
@@ -59,8 +57,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup terraform tools
-        uses: cds-snc/terraform-tools-setup@5a19984bcb888600ad646e0caf5c6f4d0a54c165 # v1.2.0
+      - name: Setup Terraform tools
+        uses: cds-snc/terraform-tools-setup@36df0d7572a15921998170395475093c183d720a # v1.3.0
+        env:
+          CONFTEST_VERSION: NONE
+          TERRAFORM_VERSION: 1.14.4
+          TERRAFORM_CHECKSUM: 4a24b18865d9419ba7882567cb7429dd1525b3e2029a9e38f612d476ba8c3dea
+          TERRAGRUNT_VERSION: 0.99.1
+          TERRAGRUNT_CHECKSUM: 7d0a7ad656cf175afdf7cb2b8a51721f4a36dbeef5fb3a37b22f1b59aaacee6d
+          TF_SUMMARIZE_VERSION: NONE
+          TRUFFLEHOG_VERSION: NONE
 
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/.github/workflows/tf-drift-check-prod.yml
+++ b/.github/workflows/tf-drift-check-prod.yml
@@ -11,8 +11,6 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.14.4
-  TERRAGRUNT_VERSION: 0.99.1
   TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.PROD_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
   TF_VAR_google_oauth_client_id: ${{ secrets.PROD_GOOGLE_OAUTH_CLIENT_ID }}
   TF_VAR_google_oauth_client_secret: ${{ secrets.PROD_GOOGLE_OAUTH_CLIENT_SECRET }}
@@ -75,8 +73,16 @@ jobs:
           persist-credentials: false
           ref: ${{ env.VERSION }}
 
-      - name: Setup terraform tools
-        uses: cds-snc/terraform-tools-setup@5a19984bcb888600ad646e0caf5c6f4d0a54c165 # v1.2.0
+      - name: Setup Terraform tools
+        uses: cds-snc/terraform-tools-setup@36df0d7572a15921998170395475093c183d720a # v1.3.0
+        env:
+          CONFTEST_VERSION: NONE
+          TERRAFORM_VERSION: 1.14.4
+          TERRAFORM_CHECKSUM: 4a24b18865d9419ba7882567cb7429dd1525b3e2029a9e38f612d476ba8c3dea
+          TERRAGRUNT_VERSION: 0.99.1
+          TERRAGRUNT_CHECKSUM: 7d0a7ad656cf175afdf7cb2b8a51721f4a36dbeef5fb3a37b22f1b59aaacee6d
+          TF_SUMMARIZE_VERSION: NONE
+          TRUFFLEHOG_VERSION: NONE
 
       - name: Check for drift
         working-directory: ./terragrunt/env/prod

--- a/.github/workflows/tf-drift-check-staging.yml
+++ b/.github/workflows/tf-drift-check-staging.yml
@@ -11,8 +11,6 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.14.4
-  TERRAGRUNT_VERSION: 0.99.1
   TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.STAGING_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
   TF_VAR_google_oauth_client_id: ${{ secrets.STAGING_GOOGLE_OAUTH_CLIENT_ID }}
   TF_VAR_google_oauth_client_secret: ${{ secrets.STAGING_GOOGLE_OAUTH_CLIENT_SECRET }}
@@ -50,8 +48,16 @@ jobs:
           role-session-name: TFPlan
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Setup terraform tools
-        uses: cds-snc/terraform-tools-setup@5a19984bcb888600ad646e0caf5c6f4d0a54c165 # v1.2.0
+      - name: Setup Terraform tools
+        uses: cds-snc/terraform-tools-setup@36df0d7572a15921998170395475093c183d720a # v1.3.0
+        env:
+          CONFTEST_VERSION: NONE
+          TERRAFORM_VERSION: 1.14.4
+          TERRAFORM_CHECKSUM: 4a24b18865d9419ba7882567cb7429dd1525b3e2029a9e38f612d476ba8c3dea
+          TERRAGRUNT_VERSION: 0.99.1
+          TERRAGRUNT_CHECKSUM: 7d0a7ad656cf175afdf7cb2b8a51721f4a36dbeef5fb3a37b22f1b59aaacee6d
+          TF_SUMMARIZE_VERSION: NONE
+          TRUFFLEHOG_VERSION: NONE
 
       - name: Check for drift
         working-directory: ./terragrunt/env/staging

--- a/.github/workflows/tf-plan-prod.yml
+++ b/.github/workflows/tf-plan-prod.yml
@@ -13,10 +13,6 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.14.4
-  TERRAGRUNT_VERSION: 0.99.1
-  TF_SUMMARIZE_VERSION: 0.3.5
-  TRUFFLEHOG_VERSION: 3.90.12
   TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.PROD_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
   TF_VAR_google_oauth_client_id: ${{ secrets.PROD_GOOGLE_OAUTH_CLIENT_ID }}
   TF_VAR_google_oauth_client_secret: ${{ secrets.PROD_GOOGLE_OAUTH_CLIENT_SECRET }}
@@ -75,8 +71,19 @@ jobs:
           ref: ${{ env.VERSION }}
           persist-credentials: false
 
-      - name: Setup terraform tools
-        uses: cds-snc/terraform-tools-setup@5a19984bcb888600ad646e0caf5c6f4d0a54c165 # v1.2.0
+      - name: Setup Terraform tools
+        uses: cds-snc/terraform-tools-setup@36df0d7572a15921998170395475093c183d720a # v1.3.0
+        env:
+          CONFTEST_VERSION: 0.36.0 
+          CONFTEST_CHECKSUM: d98783276c4fd47c779a1ece4c0decba9ee6462687839d25389882a468c362cc
+          TERRAFORM_VERSION: 1.14.4
+          TERRAFORM_CHECKSUM: 4a24b18865d9419ba7882567cb7429dd1525b3e2029a9e38f612d476ba8c3dea
+          TERRAGRUNT_VERSION: 0.99.1
+          TERRAGRUNT_CHECKSUM: 7d0a7ad656cf175afdf7cb2b8a51721f4a36dbeef5fb3a37b22f1b59aaacee6d
+          TF_SUMMARIZE_VERSION: 0.3.5
+          TF_SUMMARIZE_CHECKSUM: e0ea7b514f7a57a85e5e4594acdccbf2dce3af7e00fe90580b2ad9cc1288d317
+          TRUFFLEHOG_VERSION: 3.90.12
+          TRUFFLEHOG_CHECKSUM: 318fd1e8af68b54f4465437208582003a5948293ea401c5c67bb55f17e4e2102
 
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/.github/workflows/tf-plan-staging.yml
+++ b/.github/workflows/tf-plan-staging.yml
@@ -15,10 +15,6 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.14.4
-  TERRAGRUNT_VERSION: 0.99.1
-  TF_SUMMARIZE_VERSION: 0.3.5
-  TRUFFLEHOG_VERSION: 3.90.12
   TF_VAR_cloudwatch_alert_slack_webhook: ${{ secrets.STAGING_CLOUDWATCH_ALERT_SLACK_WEBHOOK }}
   TF_VAR_google_oauth_client_id: ${{ secrets.STAGING_GOOGLE_OAUTH_CLIENT_ID }}
   TF_VAR_google_oauth_client_secret: ${{ secrets.STAGING_GOOGLE_OAUTH_CLIENT_SECRET }}
@@ -58,8 +54,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup terraform tools
-        uses: cds-snc/terraform-tools-setup@5a19984bcb888600ad646e0caf5c6f4d0a54c165 # v1.2.0
+      - name: Setup Terraform tools
+        uses: cds-snc/terraform-tools-setup@36df0d7572a15921998170395475093c183d720a # v1.3.0
+        env:
+          CONFTEST_VERSION: 0.36.0 
+          CONFTEST_CHECKSUM: d98783276c4fd47c779a1ece4c0decba9ee6462687839d25389882a468c362cc
+          TERRAFORM_VERSION: 1.14.4
+          TERRAFORM_CHECKSUM: 4a24b18865d9419ba7882567cb7429dd1525b3e2029a9e38f612d476ba8c3dea
+          TERRAGRUNT_VERSION: 0.99.1
+          TERRAGRUNT_CHECKSUM: 7d0a7ad656cf175afdf7cb2b8a51721f4a36dbeef5fb3a37b22f1b59aaacee6d
+          TF_SUMMARIZE_VERSION: 0.3.5
+          TF_SUMMARIZE_CHECKSUM: e0ea7b514f7a57a85e5e4594acdccbf2dce3af7e00fe90580b2ad9cc1288d317
+          TRUFFLEHOG_VERSION: 3.90.12
+          TRUFFLEHOG_CHECKSUM: 318fd1e8af68b54f4465437208582003a5948293ea401c5c67bb55f17e4e2102
 
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0


### PR DESCRIPTION
# Summary
Upgrade to latest release and provide checksums we control to validate the binaries.

Update the Docker vulnerability scan workflow to build and scan a local image rather than pulling from the ECR.
