### PR TITLE
fix: allow WriteData to write Annotations

### DIFF
--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -498,6 +498,7 @@ FAB_ROLES = {
         ["UserOAuthModelView", "can_userinfo"],
     ],
     "WriteData": [
+        ["Annotation", "can_write"],
         ["Chart", "can_write"],
         ["Charts", "menu_access"],
         ["Dashboard", "can_write"],


### PR DESCRIPTION
# Summary
Update the `WriteData` role so that it has permission to create and manage Annotations.
