### PR TITLE
feat: least privileged docker oidc roles

### DIFF
--- a/.github/workflows/docker-apply-prod.yml
+++ b/.github/workflows/docker-apply-prod.yml
@@ -62,11 +62,10 @@ jobs:
         ref: ${{ env.VERSION }}
         persist-credentials: false
 
-    # TODO: Replace with a locked down IAM role
     - name: configure aws credentials using OIDC
       uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
-        role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-apply 
+        role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-docker-push
         role-session-name: PushContainer
         aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/docker-apply-staging.yml
+++ b/.github/workflows/docker-apply-staging.yml
@@ -36,11 +36,10 @@ jobs:
       with:
         persist-credentials: false
 
-    # TODO: Replace with a locked down IAM role
     - name: configure aws credentials using OIDC
       uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
-        role-to-assume: arn:aws:iam::${{ vars.STAGING_AWS_ACCOUNT_ID }}:role/cds-superset-apply 
+        role-to-assume: arn:aws:iam::${{ vars.STAGING_AWS_ACCOUNT_ID }}:role/cds-superset-docker-push
         role-session-name: PushContainer
         aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/docker-deploy-prod.yml
+++ b/.github/workflows/docker-deploy-prod.yml
@@ -58,11 +58,10 @@ jobs:
         DNS_PROXY_SAFELIST: "${{ vars.DNS_PROXY_SAFELIST }}"
         DNS_PROXY_WILDCARDGREEDY: "true"
 
-    # TODO: Replace with a locked down IAM role
     - name: configure aws credentials using OIDC
       uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
-        role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-apply 
+        role-to-assume: arn:aws:iam::${{ vars.PROD_AWS_ACCOUNT_ID }}:role/cds-superset-docker-deploy
         role-session-name: DeployContainer
         aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/docker-deploy-staging.yml
+++ b/.github/workflows/docker-deploy-staging.yml
@@ -35,11 +35,10 @@ jobs:
         DNS_PROXY_SAFELIST: "${{ vars.DNS_PROXY_SAFELIST }}"
         DNS_PROXY_WILDCARDGREEDY: "true"
 
-    # TODO: Replace with a locked down IAM role
     - name: configure aws credentials using OIDC
       uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
       with:
-        role-to-assume: arn:aws:iam::${{ vars.STAGING_AWS_ACCOUNT_ID }}:role/cds-superset-apply 
+        role-to-assume: arn:aws:iam::${{ vars.STAGING_AWS_ACCOUNT_ID }}:role/cds-superset-docker-deploy
         role-session-name: DeployContainer
         aws-region: ${{ env.AWS_REGION }}
 

--- a/terragrunt/aws/oidc.tf
+++ b/terragrunt/aws/oidc.tf
@@ -80,8 +80,8 @@ resource "aws_iam_policy" "docker_deploy" {
   policy = data.aws_iam_policy_document.docker_deploy.json
 }
 
+#trivy:ignore:AVD-AWS-0342
 data "aws_iam_policy_document" "docker_deploy" {
-  #trivy:ignore:AVD-AWS-0342
   statement {
     effect = "Allow"
     actions = [

--- a/terragrunt/aws/oidc.tf
+++ b/terragrunt/aws/oidc.tf
@@ -104,7 +104,8 @@ data "aws_iam_policy_document" "docker_deploy" {
       "iam:PassRole",
     ]
     resources = [
-      "arn:aws:iam::${var.account_id}:role/superset*",
+      "arn:aws:iam::${var.account_id}:role/superset_ecs_task_exec_role",
+      "arn:aws:iam::${var.account_id}:role/superset_ecs_task_role",
     ]
   }
 
@@ -114,7 +115,9 @@ data "aws_iam_policy_document" "docker_deploy" {
       "ssm:PutParameter",
     ]
     resources = [
-      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/ecs/superset/*/container-image",
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/ecs/superset/superset/container-image",
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/ecs/superset/celery-worker/container-image",
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/ecs/superset/celery-beat/container-image",
     ]
   }
 }

--- a/terragrunt/aws/oidc.tf
+++ b/terragrunt/aws/oidc.tf
@@ -23,10 +23,6 @@ module "github_workflow_roles" {
   billing_tag_value = var.billing_code
 }
 
-#
-# Docker push role — used by docker-apply-staging and docker-apply-prod workflows
-#
-
 resource "aws_iam_role_policy_attachment" "docker_push" {
   role       = local.docker_push_role
   policy_arn = aws_iam_policy.docker_push.arn
@@ -62,10 +58,6 @@ data "aws_iam_policy_document" "docker_push" {
     resources = [aws_ecr_repository.superset-image.arn]
   }
 }
-
-#
-# Docker deploy role — used by docker-deploy-staging and docker-deploy-prod workflows
-#
 
 resource "aws_iam_role_policy_attachment" "docker_deploy" {
   role       = local.docker_deploy_role

--- a/terragrunt/aws/oidc.tf
+++ b/terragrunt/aws/oidc.tf
@@ -1,0 +1,128 @@
+locals {
+  docker_push_role   = "${var.product_name}-docker-push"
+  docker_deploy_role = "${var.product_name}-docker-deploy"
+}
+
+module "github_workflow_roles" {
+  source = "github.com/cds-snc/terraform-modules//gh_oidc_role?ref=v10.11.4"
+
+  roles = [
+    {
+      name      = local.docker_push_role
+      repo_name = "cds-superset"
+      claim     = "ref:refs/heads/main"
+    },
+    {
+      name      = local.docker_deploy_role
+      repo_name = "cds-superset"
+      claim     = "ref:refs/heads/main"
+    }
+  ]
+
+  oidc_exists       = true
+  billing_tag_value = var.billing_code
+}
+
+#
+# Docker push role — used by docker-apply-staging and docker-apply-prod workflows
+#
+
+resource "aws_iam_role_policy_attachment" "docker_push" {
+  role       = local.docker_push_role
+  policy_arn = aws_iam_policy.docker_push.arn
+
+  depends_on = [module.github_workflow_roles]
+}
+
+resource "aws_iam_policy" "docker_push" {
+  name   = local.docker_push_role
+  path   = "/"
+  policy = data.aws_iam_policy_document.docker_push.json
+}
+
+#trivy:ignore:AVD-AWS-0342
+data "aws_iam_policy_document" "docker_push" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:CompleteLayerUpload",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
+    ]
+    resources = [aws_ecr_repository.superset-image.arn]
+  }
+}
+
+#
+# Docker deploy role — used by docker-deploy-staging and docker-deploy-prod workflows
+#
+
+resource "aws_iam_role_policy_attachment" "docker_deploy" {
+  role       = local.docker_deploy_role
+  policy_arn = aws_iam_policy.docker_deploy.arn
+
+  depends_on = [module.github_workflow_roles]
+}
+
+resource "aws_iam_policy" "docker_deploy" {
+  name   = local.docker_deploy_role
+  path   = "/"
+  policy = data.aws_iam_policy_document.docker_deploy.json
+}
+
+data "aws_iam_policy_document" "docker_deploy" {
+  #trivy:ignore:AVD-AWS-0342
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecs:DescribeTaskDefinition",
+      "ecs:RegisterTaskDefinition",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecs:DescribeServices",
+      "ecs:DescribeTasks",
+      "ecs:RunTask",
+      "ecs:UpdateService",
+    ]
+    resources = [
+      "arn:aws:ecs:${var.region}:${var.account_id}:cluster/superset",
+      "arn:aws:ecs:${var.region}:${var.account_id}:service/superset/*",
+      "arn:aws:ecs:${var.region}:${var.account_id}:task/superset/*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:PassRole",
+    ]
+    resources = [
+      "arn:aws:iam::${var.account_id}:role/superset*",
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssm:PutParameter",
+    ]
+    resources = [
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/ecs/superset/*/container-image",
+    ]
+  }
+}


### PR DESCRIPTION
# Summary | Résumé

- Scoped down OIDC roles for Docker workflows replacing the `cds-superset-apply` admin role
- `cds-superset-docker-push` only has ECR push permissions, used by build and push workflows
- `cds-superset-docker-deploy` ECS task definition and service update permissions only, used by deploy workflows

Related to: https://github.com/orgs/cds-snc/projects/51?pane=issue&itemId=164542666&issue=cds-snc%7Cplatform-core-services%7C958