### PR TITLE
fix: add iam:PassRole for celery-beat and celery-worker task roles

### DIFF
--- a/terragrunt/aws/oidc.tf
+++ b/terragrunt/aws/oidc.tf
@@ -107,6 +107,10 @@ data "aws_iam_policy_document" "docker_deploy" {
     resources = [
       "arn:aws:iam::${var.account_id}:role/superset_ecs_task_exec_role",
       "arn:aws:iam::${var.account_id}:role/superset_ecs_task_role",
+      "arn:aws:iam::${var.account_id}:role/celery-worker_ecs_task_exec_role",
+      "arn:aws:iam::${var.account_id}:role/celery-worker_ecs_task_role",
+      "arn:aws:iam::${var.account_id}:role/celery-beat_ecs_task_exec_role",
+      "arn:aws:iam::${var.account_id}:role/celery-beat_ecs_task_role",
     ]
   }
 


### PR DESCRIPTION
# Summary | Résumé

The `cds-superset-docker-deploy` role was missing the following permissions:

- `celery-worker_ecs_task_exec_role`
- `celery-worker_ecs_task_role`
- `celery-beat_ecs_task_exec_rol`
- `celery-beat_ecs_task_role`
