### PR TITLE
feat: github workflow static analysis

### DIFF
--- a/.github/workflows/docker-apply-prod.yml
+++ b/.github/workflows/docker-apply-prod.yml
@@ -11,9 +11,7 @@ env:
   AWS_REGION: ca-central-1
   REGISTRY: ${{ vars.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/superset
 
-permissions:
-  id-token: write
-  contents: write
+permissions: {}
   
 jobs:
   get-version:
@@ -44,6 +42,9 @@ jobs:
   docker-push:
     runs-on: ubuntu-24.04-arm
     needs: get-version
+    permissions:
+      id-token: write
+      contents: read
     env:
       VERSION: ${{ needs.get-version.outputs.version }}
     steps:

--- a/.github/workflows/docker-apply-staging.yml
+++ b/.github/workflows/docker-apply-staging.yml
@@ -15,13 +15,14 @@ env:
   REGISTRY: ${{ vars.STAGING_AWS_ACCOUNT_ID }}.dkr.ecr.ca-central-1.amazonaws.com/superset
   GITHUB_SHA: ${{ github.sha }}
 
-permissions:
-  id-token: write
-  contents: write
+permissions: {}
   
 jobs:
   docker-push:
     runs-on: ubuntu-24.04-arm
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - name: Audit DNS requests
       uses: cds-snc/dns-proxy-action@9ad793100229573be3f5ba78cc69ec523f2c8b7e # v1.1.0

--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -72,10 +72,12 @@ jobs:
         propagate-tags: SERVICE
 
     - name: Update SSM parameter for deployed image
+      env:
+        IMAGE_TAG: ${{ inputs.image_tag }}
       run: |
         aws ssm put-parameter \
           --name "/ecs/${{ env.ECS_CLUSTER }}/${{ matrix.service }}/container-image" \
-          --value "${{ env.REGISTRY }}:${{ inputs.image_tag }}" \
+          --value "${{ env.REGISTRY }}:${IMAGE_TAG}" \
           --type "String" \
           --overwrite
 

--- a/.github/workflows/get-version/action.yml
+++ b/.github/workflows/get-version/action.yml
@@ -13,13 +13,15 @@ runs:
   using: "composite"
   steps:
     - name: Get version, release PR branch
+      id: version-from-branch
       if: inputs.is-tagged == 'false' && startsWith(github.head_ref, 'release-please--')
       env:
         GITHUB_HEAD_REF: ${{ github.head_ref }}
-      run: echo "VERSION=$GITHUB_HEAD_REF" >> $GITHUB_ENV
+      run: echo "version=$GITHUB_HEAD_REF" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: Get version, perform release of tag
+      id: version-from-tag
       if: inputs.is-tagged == 'true'
       run: |
         VERSION="$(tr -d '\n\r' < version.txt)"
@@ -27,20 +29,24 @@ runs:
           echo "::error::Invalid version format in version.txt: '$VERSION'"
           exit 1
         fi
-        echo "VERSION=v${VERSION}" >> $GITHUB_ENV
+        echo "version=v${VERSION}" >> "$GITHUB_OUTPUT"
       shell: bash
 
     - name: Wait for ref to exist
       if: inputs.is-tagged == 'true'
-      run: ./.github/workflows/scripts/wait-for-ref.sh "${VERSION}"
+      env:
+        VERSION: ${{ steps.version-from-tag.outputs.version }}
+      run: ./.github/workflows/scripts/wait-for-ref.sh "$VERSION"
       shell: bash
 
     - name: Fail if no version set
-      if: env.VERSION == ''   
+      if: steps.version-from-branch.outputs.version == '' && steps.version-from-tag.outputs.version == ''   
       run: exit 1
       shell: bash
 
     - name: Output version
       id: output-version
-      run: echo "version=${VERSION}" >> $GITHUB_OUTPUT
+      env:
+        VERSION: ${{ steps.version-from-branch.outputs.version || steps.version-from-tag.outputs.version }}
+      run: echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,13 +5,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Audit DNS requests
         uses: cds-snc/dns-proxy-action@9ad793100229573be3f5ba78cc69ec523f2c8b7e # v1.1.0
@@ -27,6 +28,8 @@ jobs:
         with:
           app-id: ${{ secrets.CDS_RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.CDS_RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:

--- a/.github/workflows/tf-apply-prod.yml
+++ b/.github/workflows/tf-apply-prod.yml
@@ -30,9 +30,7 @@ env:
   TF_VAR_superset_secret_key: ${{ secrets.PROD_SUPERSET_SECRET_KEY }}
   TF_VAR_upptime_status_header: ${{ secrets.PROD_UPPTIME_STATUS_HEADER }}
   
-permissions:
-  id-token: write
-  contents: read
+permissions: {}
 
 jobs:
   get-version:
@@ -63,6 +61,9 @@ jobs:
   terragrunt-apply:
     runs-on: ubuntu-latest
     needs: get-version
+    permissions:
+      id-token: write
+      contents: read
     env:
       VERSION: ${{ needs.get-version.outputs.version }}
     steps:

--- a/.github/workflows/tf-apply-staging.yml
+++ b/.github/workflows/tf-apply-staging.yml
@@ -34,15 +34,16 @@ env:
   TF_VAR_superset_secret_key: ${{ secrets.STAGING_SUPERSET_SECRET_KEY }}
   TF_VAR_upptime_status_header: ${{ secrets.STAGING_UPPTIME_STATUS_HEADER }}
   
-permissions:
-  id-token: write
-  contents: read
+permissions: {}
 
 jobs:
   terragrunt-apply:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
 
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
 
       - name: Audit DNS requests

--- a/.github/workflows/tf-drift-check-prod.yml
+++ b/.github/workflows/tf-drift-check-prod.yml
@@ -28,13 +28,14 @@ env:
   TF_VAR_superset_secret_key: ${{ secrets.PROD_SUPERSET_SECRET_KEY }}
   TF_VAR_upptime_status_header: ${{ secrets.PROD_UPPTIME_STATUS_HEADER }}
 
-permissions:
-  id-token: write
-  contents: read
+permissions: {}
 
 jobs:
   get-version:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       version: ${{ steps.get-version.outputs.version }}
     steps:

--- a/.github/workflows/tf-drift-check-staging.yml
+++ b/.github/workflows/tf-drift-check-staging.yml
@@ -28,13 +28,14 @@ env:
   TF_VAR_superset_secret_key: ${{ secrets.STAGING_SUPERSET_SECRET_KEY }}
   TF_VAR_upptime_status_header: ${{ secrets.STAGING_UPPTIME_STATUS_HEADER }}
 
-permissions:
-  id-token: write
-  contents: read
+permissions: {}
 
 jobs:
   terraform-drift:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Audit DNS requests
         uses: cds-snc/dns-proxy-action@9ad793100229573be3f5ba78cc69ec523f2c8b7e # v1.1.0

--- a/.github/workflows/tf-plan-prod.yml
+++ b/.github/workflows/tf-plan-prod.yml
@@ -30,10 +30,7 @@ env:
   TF_VAR_superset_secret_key: ${{ secrets.PROD_SUPERSET_SECRET_KEY }}
   TF_VAR_upptime_status_header: ${{ secrets.PROD_UPPTIME_STATUS_HEADER }}
 
-permissions:
-  id-token: write
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   get-version:
@@ -63,6 +60,10 @@ jobs:
 
   terraform-plan:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
     needs: get-version
     env:
       VERSION: ${{ needs.get-version.outputs.version }}

--- a/.github/workflows/tf-plan-staging.yml
+++ b/.github/workflows/tf-plan-staging.yml
@@ -32,15 +32,16 @@ env:
   TF_VAR_superset_secret_key: ${{ secrets.STAGING_SUPERSET_SECRET_KEY }}
   TF_VAR_upptime_status_header: ${{ secrets.STAGING_UPPTIME_STATUS_HEADER }}
 
-permissions:
-  id-token: write
-  contents: read
-  pull-requests: write
+permissions: {}
 
 jobs:
   terraform-plan:
 
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
     steps:
       - name: Audit DNS requests
         uses: cds-snc/dns-proxy-action@9ad793100229573be3f5ba78cc69ec523f2c8b7e # v1.1.0

--- a/.github/workflows/workflow-failure.yml
+++ b/.github/workflows/workflow-failure.yml
@@ -27,6 +27,8 @@ jobs:
           DNS_PROXY_WILDCARDGREEDY: "true"
 
       - name: Notify Slack
+        env:
+          GITHUB_WORKFLOW: ${{ github.workflow }}
         run: |
-          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Superset workflow failed: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"}}]}'
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Superset workflow failed: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${GITHUB_WORKFLOW}>"}}]}'
           curl -X POST -H 'Content-type: application/json' --data "$json" "${{ secrets.SLACK_WEBHOOK_URL }}"

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,40 @@
+name: GitHub Actions security analysis
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Audit DNS requests
+        uses: cds-snc/dns-proxy-action@9ad793100229573be3f5ba78cc69ec523f2c8b7e # v1.1.0
+        env:
+          DNS_PROXY_FORWARDTOSENTINEL: "true"
+          DNS_PROXY_LOGANALYTICSWORKSPACEID: "${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}"
+          DNS_PROXY_LOGANALYTICSSHAREDKEY: "${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}"
+          DNS_PROXY_SAFELIST: "${{ vars.DNS_PROXY_SAFELIST }}"
+          DNS_PROXY_WILDCARDGREEDY: "true"
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          version: "1.25.2"
+          advanced-security: true
+          min-severity: high


### PR DESCRIPTION
# Summary | Résumé

Added `zizmor.yml` workflow that runs on all PRs and pushes to main, uploads SARIF results to GitHub Code Scanning, and fails the job if any high or critical findings are present

fixed the following issues that were found by zizmor:

- Script injection
- Overly broad permissions 
- GitHub ENV fix

Related:
https://github.com/cds-snc/platform-core-services/issues/959